### PR TITLE
Update GitHub Actions builds for GitHub Container Registry

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,4 +26,4 @@ about: Report a problem
 
 Relates to organization/repo#number <!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->
 
-- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
+- [ ] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,4 +19,4 @@ about: Suggest an idea for this project
 
 Relates to organization/repo#number <!-- Reference related commits, issues and pull requests. Type `#` and select from the list. -->
 
-- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
+- [ ] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,4 @@ Closes organization/repo#number
 
 <!-- List issues for GitHub to automatically close after merge to default branch. Type `#` and select from the list. See the [GitHub docs on linking PRs to issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for more. -->
 
-- [ ] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
+- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -50,24 +50,24 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Log in to Docker registry
-        run: docker login https://docker.pkg.github.com -u ${{ github.actor }} -p ${{ github.token }}
+        run: docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.PAT_GHCR }}
       - name: Build Docker images
         run: |
-          docker build . --rm --target base -t docker.pkg.github.com/br3ndonland/inboard/base:latest --cache-from python:3.8
-          docker build . --rm --target fastapi -t docker.pkg.github.com/br3ndonland/inboard/fastapi:latest
-          docker build . --rm --target starlette -t docker.pkg.github.com/br3ndonland/inboard/starlette:latest
+          docker build . --rm --target base -t ghcr.io/br3ndonland/inboard/base:latest --cache-from python:3.8
+          docker build . --rm --target fastapi -t ghcr.io/br3ndonland/inboard/fastapi:latest
+          docker build . --rm --target starlette -t ghcr.io/br3ndonland/inboard/starlette:latest
       - name: Push Docker images to registry
         run: |
-          docker push docker.pkg.github.com/br3ndonland/inboard/base:latest
-          docker push docker.pkg.github.com/br3ndonland/inboard/fastapi:latest
-          docker push docker.pkg.github.com/br3ndonland/inboard/starlette:latest
+          docker push ghcr.io/br3ndonland/inboard/base:latest
+          docker push ghcr.io/br3ndonland/inboard/fastapi:latest
+          docker push ghcr.io/br3ndonland/inboard/starlette:latest
       - name: Add Git tag to Docker images if workflow was triggered by pushing a tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           GIT_TAG=$(echo ${{ github.ref }} | cut -d / -f 3)
-          docker tag docker.pkg.github.com/br3ndonland/inboard/base docker.pkg.github.com/br3ndonland/inboard/base:"$GIT_TAG"
-          docker tag docker.pkg.github.com/br3ndonland/inboard/fastapi docker.pkg.github.com/br3ndonland/inboard/fastapi:"$GIT_TAG"
-          docker tag docker.pkg.github.com/br3ndonland/inboard/starlette docker.pkg.github.com/br3ndonland/inboard/starlette:"$GIT_TAG"
-          docker push docker.pkg.github.com/br3ndonland/inboard/base:"$GIT_TAG"
-          docker push docker.pkg.github.com/br3ndonland/inboard/fastapi:"$GIT_TAG"
-          docker push docker.pkg.github.com/br3ndonland/inboard/starlette:"$GIT_TAG"
+          docker tag ghcr.io/br3ndonland/inboard/base ghcr.io/br3ndonland/inboard/base:"$GIT_TAG"
+          docker tag ghcr.io/br3ndonland/inboard/fastapi ghcr.io/br3ndonland/inboard/fastapi:"$GIT_TAG"
+          docker tag ghcr.io/br3ndonland/inboard/starlette ghcr.io/br3ndonland/inboard/starlette:"$GIT_TAG"
+          docker push ghcr.io/br3ndonland/inboard/base:"$GIT_TAG"
+          docker push ghcr.io/br3ndonland/inboard/fastapi:"$GIT_TAG"
+          docker push ghcr.io/br3ndonland/inboard/starlette:"$GIT_TAG"


### PR DESCRIPTION
## Description

[GitHub Container Registry (GHCR) was released today](https://github.blog/2020-09-01-introducing-github-container-registry/)! :tada:

This PR will update the GitHub Actions workflow to push to GHCR instead of GitHub Packages.

The [migration](https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images) was simple:

- Update registry URLs from `docker.pkg.github.io` to `ghcr.io`
- Generate Personal Access Token (PAT) and use to authenticate to GHCR

## Changes

- Update builds for GitHub Container Registry (71c9ddf)
- Update README for GitHub Container Registry (ebab152)

## Related

br3ndonland/inboard#5

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).