### PR TITLE
Increase unit test coverage to 100%

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -208,7 +208,7 @@ After saving files, changes need to be committed to the Git repository.
 - Python 3 (modern Python) was used. Python 2 (legacy Python) is nearing its [end of life](https://pythonclock.org/).
 - Python code was linted with [Flake8](https://flake8.readthedocs.io/en/latest/) and autoformatted with [Black](https://black.readthedocs.io/en/stable/).
 - Git pre-commit hooks have been installed for the [Black autoformatter](https://black.readthedocs.io/en/stable/version_control_integration.html) and [Flake8 linter](https://flake8.pycqa.org/en/latest/user/using-hooks.html).
-- Within Python modules, `import` statements are organized automatically by [isort](https://timothycrosley.github.io/isort/).
+- Within Python modules, `import` statements are organized automatically by [isort](https://pycqa.github.io/isort/).
 - In general, a [Pythonic](https://docs.python-guide.org/writing/style/) code style following the [Zen of Python](https://www.python.org/dev/peps/pep-0020/) was used. [Foolish consistency](https://pep8.org) was avoided.
 
 ### Python virtual environment tools

--- a/README.md
+++ b/README.md
@@ -348,6 +348,27 @@ For more information on Python logging configuration, see the [Python `logging` 
   - You can run isort from the command line with `poetry run isort .`.
   - Configuration for isort is stored in _[pyproject.toml](pyproject.toml)_.
 - Other web code (JSON, Markdown, YAML) is formatted with [Prettier](https://prettier.io/).
+- Code style is enforced with [pre-commit](https://pre-commit.com/), which runs [Git hooks](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).
+
+  - Configuration is stored in _[.pre-commit-config.yaml](.pre-commit-config.yaml)_.
+  - Pre-commit can run locally before each commit (hence "pre-commit"), or on different Git events like `pre-push`.
+  - Pre-commit is installed in the Poetry environment. To use:
+
+    ```sh
+    # after running `poetry install`
+    path/to/inboard
+    ❯ poetry shell
+
+    # install hooks that run before each commit
+    path/to/inboard
+    .venv ❯ pre-commit install
+
+    # and/or install hooks that run before each push
+    path/to/inboard
+    .venv ❯ pre-commit install --hook-type pre-push
+    ```
+
+  - Pre-commit is also useful as a CI tool. The [hooks](.github/workflows/hooks.yml) GitHub Actions workflow runs pre-commit hooks with [GitHub Actions](https://github.com/features/actions).
 
 ### GitHub Actions workflows
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Brendon Smith ([br3ndonland](https://github.com/br3ndonland/))
   - [Logging](#logging)
 - [Development](#development)
   - [Code style](#code-style)
+  - [Testing with pytest](#testing-with-pytest)
   - [GitHub Actions workflows](#github-actions-workflows)
   - [Building development images](#building-development-images)
   - [Running development containers](#running-development-containers)
@@ -369,6 +370,23 @@ For more information on Python logging configuration, see the [Python `logging` 
     ```
 
   - Pre-commit is also useful as a CI tool. The [hooks](.github/workflows/hooks.yml) GitHub Actions workflow runs pre-commit hooks with [GitHub Actions](https://github.com/features/actions).
+
+### Testing with pytest
+
+- Tests are in the _tests/_ directory.
+- Run tests by [invoking `pytest` from the command-line](https://docs.pytest.org/en/stable/usage.html) in the root directory of the repo.
+- [pytest](https://docs.pytest.org/en/latest/) features used include:
+  - [fixtures](https://docs.pytest.org/en/latest/fixture.html)
+  - [monkeypatch](https://docs.pytest.org/en/latest/monkeypatch.html)
+  - [parametrize](https://docs.pytest.org/en/latest/parametrize.html)
+  - [`tmp_path`](https://docs.pytest.org/en/latest/tmpdir.html)
+- [pytest plugins](https://docs.pytest.org/en/stable/plugins.html) include:
+  - [pytest-cov](https://github.com/pytest-dev/pytest-cov)
+  - [pytest-mock](https://github.com/pytest-dev/pytest-mock)
+- [pytest configuration](https://docs.pytest.org/en/stable/customize.html) is in _[pyproject.toml](pyproject.toml)_.
+- [FastAPI testing](https://fastapi.tiangolo.com/tutorial/testing/) and [Starlette testing](https://www.starlette.io/testclient/) rely on the [Starlette `TestClient`](https://www.starlette.io/testclient/), which uses [Requests](https://requests.readthedocs.io/en/master/) under the hood.
+- Test coverage results are reported when invoking `pytest` from the command-line. To see interactive HTML coverage reports, invoke pytest with `pytest --cov-report=html`.
+- Test coverage reports are generated within GitHub Actions workflows by [pytest-cov](https://github.com/pytest-dev/pytest-cov) with [coverage.py](https://github.com/nedbat/coveragepy), and uploaded to [Codecov](https://docs.codecov.io/docs) using [codecov/codecov-action](https://github.com/marketplace/actions/codecov). Codecov is then integrated into pull requests with the [Codecov GitHub app](https://github.com/marketplace/codecov).
 
 ### GitHub Actions workflows
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Brendon Smith ([br3ndonland](https://github.com/br3ndonland/))
   - [Logging](#logging)
 - [Development](#development)
   - [Code style](#code-style)
+  - [GitHub Actions workflows](#github-actions-workflows)
   - [Building development images](#building-development-images)
   - [Running development containers](#running-development-containers)
   - [Configuring Docker for GitHub Container Registry](#configuring-docker-for-github-container-registry)
@@ -347,6 +348,10 @@ For more information on Python logging configuration, see the [Python `logging` 
   - You can run isort from the command line with `poetry run isort .`.
   - Configuration for isort is stored in _[pyproject.toml](pyproject.toml)_.
 - Other web code (JSON, Markdown, YAML) is formatted with [Prettier](https://prettier.io/).
+
+### GitHub Actions workflows
+
+[GitHub Actions](https://github.com/features/actions) is a continuous integration/continuous deployment (CI/CD) service that runs on GitHub repos. It replaces other services like Travis CI. Actions are grouped into workflows and stored in _.github/workflows_. See my [GitHub Actions Gist](https://gist.github.com/br3ndonland/f9c753eb27381f97336aa21b8d932be6) for more info on GitHub Actions.
 
 ### Building development images
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ For more information on Python logging configuration, see the [Python `logging` 
 ### Code style
 
 - Python code is formatted with [Black](https://black.readthedocs.io/en/stable/). Configuration for Black is stored in _[pyproject.toml](pyproject.toml)_.
-- Python imports are organized automatically with [isort](https://timothycrosley.github.io/isort/).
+- Python imports are organized automatically with [isort](https://pycqa.github.io/isort/).
   - The isort package organizes imports in three sections:
     1. Standard library
     2. Dependencies

--- a/inboard/__init__.py
+++ b/inboard/__init__.py
@@ -5,10 +5,10 @@ inboard
 from importlib.metadata import version
 
 
-def package_version() -> str:
+def package_version(package: str = __package__) -> str:
     """Calculate version number based on pyproject.toml"""
     try:
-        return version(__package__)
+        return version(package)
     except Exception:
         return "Package not found."
 

--- a/inboard/app/base/main.py
+++ b/inboard/app/base/main.py
@@ -24,11 +24,10 @@ class App:
             }
         )
         version = f"{sys.version_info.major}.{sys.version_info.minor}"
-        server = (
-            "Uvicorn"
-            if os.getenv("PROCESS_MANAGER") == "uvicorn"
-            else "Uvicorn, Gunicorn,"
-        )
+        process_manager = os.getenv("PROCESS_MANAGER")
+        if process_manager not in ["gunicorn", "uvicorn"]:
+            raise NameError("Process manager needs to be either uvicorn or gunicorn.")
+        server = "Uvicorn" if process_manager == "uvicorn" else "Uvicorn, Gunicorn,"
         message = f"Hello World, from {server} and Python {version}!"
         response: Dict = {"type": "http.response.body", "body": message.encode("utf-8")}
         await send(response)

--- a/inboard/app/base/main.py
+++ b/inboard/app/base/main.py
@@ -24,11 +24,15 @@ class App:
             }
         )
         version = f"{sys.version_info.major}.{sys.version_info.minor}"
-        server = "Uvicorn" if bool(os.getenv("WITH_RELOAD")) else "Uvicorn, Gunicorn,"
+        server = (
+            "Uvicorn"
+            if os.getenv("PROCESS_MANAGER") == "uvicorn"
+            else "Uvicorn, Gunicorn,"
+        )
         message = f"Hello World, from {server} and Python {version}!"
         response: Dict = {"type": "http.response.body", "body": message.encode("utf-8")}
         await send(response)
         return response
 
 
-app = App
+app: Callable = App

--- a/inboard/app/utilities.py
+++ b/inboard/app/utilities.py
@@ -1,5 +1,4 @@
 import base64
-import binascii
 import os
 from secrets import compare_digest
 from typing import Tuple, Union
@@ -27,18 +26,18 @@ class BasicAuth(AuthenticationBackend):
             scheme, credentials = auth.split()
             decoded = base64.b64decode(credentials).decode("ascii")
             username, _, password = decoded.partition(":")
-        except (ValueError, UnicodeDecodeError, binascii.Error):
-            raise AuthenticationError("Unable to parse basic auth credentials")
-        correct_username = compare_digest(
-            username, str(os.getenv("BASIC_AUTH_USERNAME", "test_username"))
-        )
-        correct_password = compare_digest(
-            password,
-            str(os.getenv("BASIC_AUTH_PASSWORD", "plunge-germane-tribal-pillar")),
-        )
-        if not (correct_username and correct_password):
-            raise AuthenticationError("Invalid basic auth credentials")
-        return AuthCredentials(["authenticated"]), SimpleUser(username)
+            correct_username = compare_digest(
+                username, str(os.getenv("BASIC_AUTH_USERNAME", "test_username"))
+            )
+            correct_password = compare_digest(
+                password,
+                str(os.getenv("BASIC_AUTH_PASSWORD", "plunge-germane-tribal-pillar")),
+            )
+            if not (correct_username and correct_password):
+                raise AuthenticationError("Invalid basic auth credentials")
+            return AuthCredentials(["authenticated"]), SimpleUser(username)
+        except Exception:
+            raise
 
 
 def basic_auth(credentials: HTTPBasicCredentials = Depends(HTTPBasic())) -> str:

--- a/inboard/gunicorn_conf.py
+++ b/inboard/gunicorn_conf.py
@@ -3,13 +3,13 @@ import os
 
 from inboard.start import configure_logging
 
-workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
+# Gunicorn setup
 max_workers_str = os.getenv("MAX_WORKERS")
-use_max_workers = None
-if max_workers_str:
-    use_max_workers = int(max_workers_str)
 web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
-
+workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
+use_max_workers = None
+if max_workers_str and int(max_workers_str) > 0:
+    use_max_workers = int(max_workers_str)
 host = os.getenv("HOST", "0.0.0.0")
 port = os.getenv("PORT", "80")
 bind_env = os.getenv("BIND", None)
@@ -18,9 +18,8 @@ use_bind = bind_env if bind_env else f"{host}:{port}"
 cores = multiprocessing.cpu_count()
 workers_per_core = float(workers_per_core_str)
 default_web_concurrency = workers_per_core * cores
-if web_concurrency_str:
+if web_concurrency_str and int(web_concurrency_str) > 0:
     web_concurrency = int(web_concurrency_str)
-    assert web_concurrency > 0
 else:
     web_concurrency = max(int(default_web_concurrency), 2)
     if use_max_workers:

--- a/inboard/gunicorn_conf.py
+++ b/inboard/gunicorn_conf.py
@@ -1,7 +1,5 @@
-import json
 import multiprocessing
 import os
-from pathlib import Path
 
 from inboard.start import configure_logging
 
@@ -36,14 +34,9 @@ timeout_str = os.getenv("TIMEOUT", "120")
 keepalive_str = os.getenv("KEEP_ALIVE", "5")
 
 # Gunicorn config variables
-try:
-    logconfig_dict = configure_logging(
-        logging_conf=os.getenv("LOGGING_CONF", "inboard.logging_conf")
-    )
-except Exception as e:
-    if use_loglevel == "debug":
-        msg = "Error loading logging config with Gunicorn:"
-        print(f"[{Path(__file__).stem}] {msg} {e}")
+logconfig_dict = configure_logging(
+    logging_conf=os.getenv("LOGGING_CONF", "inboard.logging_conf")
+)
 loglevel = use_loglevel
 workers = web_concurrency
 bind = use_bind
@@ -53,22 +46,3 @@ accesslog = use_accesslog
 graceful_timeout = int(graceful_timeout_str)
 timeout = int(timeout_str)
 keepalive = int(keepalive_str)
-
-log_data = {
-    # General
-    "host": host,
-    "port": port,
-    "use_max_workers": use_max_workers,
-    "workers_per_core": workers_per_core,
-    # Gunicorn
-    "loglevel": loglevel,
-    "workers": workers,
-    "bind": bind,
-    "graceful_timeout": graceful_timeout,
-    "timeout": timeout,
-    "keepalive": keepalive,
-    "errorlog": errorlog,
-    "accesslog": accesslog,
-}
-if loglevel == "debug":
-    print(f"[{Path(__file__).stem}] Custom configuration:", json.dumps(log_data))

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -102,6 +102,18 @@ class TestEndpoints:
         assert response.status_code == 200
         assert response.text == "Hello World, from Uvicorn, Gunicorn, and Python 3.8!"
 
+    def test_get_asgi_incorrect_process_manager(
+        self, client_asgi: TestClient, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Test `GET` request to base ASGI app with incorrect `PROCESS_MANAGER`."""
+        monkeypatch.setenv("PROCESS_MANAGER", "incorrect")
+        monkeypatch.setenv("WITH_RELOAD", "false")
+        assert os.getenv("PROCESS_MANAGER") == "incorrect"
+        assert os.getenv("WITH_RELOAD") == "false"
+        with pytest.raises(NameError) as e:
+            client_asgi.get("/")
+            assert str(e) == "Process manager needs to be either uvicorn or gunicorn."
+
     def test_get_root(self, clients: List[TestClient]) -> None:
         """Test a `GET` request to the root endpoint."""
         for client in clients:

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -1,7 +1,9 @@
+import os
 import re
 from typing import Dict, List
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from starlette.applications import Starlette
@@ -75,6 +77,30 @@ class TestEndpoints:
     - https://www.starlette.io/testclient/
     - https://docs.pytest.org/en/latest/parametrize.html
     """
+
+    def test_get_asgi_uvicorn(
+        self, client_asgi: TestClient, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Test `GET` request to base ASGI app set for Uvicorn without Gunicorn."""
+        monkeypatch.setenv("PROCESS_MANAGER", "uvicorn")
+        monkeypatch.setenv("WITH_RELOAD", "false")
+        assert os.getenv("PROCESS_MANAGER") == "uvicorn"
+        assert os.getenv("WITH_RELOAD") == "false"
+        response = client_asgi.get("/")
+        assert response.status_code == 200
+        assert response.text == "Hello World, from Uvicorn and Python 3.8!"
+
+    def test_get_asgi_uvicorn_gunicorn(
+        self, client_asgi: TestClient, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Test `GET` request to base ASGI app set for Uvicorn with Gunicorn."""
+        monkeypatch.setenv("PROCESS_MANAGER", "gunicorn")
+        monkeypatch.setenv("WITH_RELOAD", "false")
+        assert os.getenv("PROCESS_MANAGER") == "gunicorn"
+        assert os.getenv("WITH_RELOAD") == "false"
+        response = client_asgi.get("/")
+        assert response.status_code == 200
+        assert response.text == "Hello World, from Uvicorn, Gunicorn, and Python 3.8!"
 
     def test_get_root(self, clients: List[TestClient]) -> None:
         """Test a `GET` request to the root endpoint."""

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -153,6 +153,20 @@ class TestEndpoints:
             response = client.get(endpoint, auth=basic_auth)
             assert response.status_code == 200
 
+    @pytest.mark.parametrize("endpoint", ["/health", "/status"])
+    def test_gets_with_starlette_auth_exception(
+        self, clients: List[TestClient], endpoint: str
+    ) -> None:
+        """Test Starlette `GET` requests with incorrect Basic Auth credentials."""
+        starlette_client = clients[1]
+        assert isinstance(starlette_client.app, Starlette)
+        response = starlette_client.get(endpoint, auth=("user", "pass"))
+        assert response.status_code in [401, 403]
+        assert response.json() == {
+            "detail": "Incorrect username or password",
+            "error": "Invalid basic auth credentials",
+        }
+
     def test_get_status_message(
         self,
         basic_auth: tuple,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from pytest_mock import MockerFixture
 from inboard import gunicorn_conf as gunicorn_conf_module
 from inboard import logging_conf as logging_conf_module
 from inboard.app import prestart as pre_start_module
+from inboard.app.base.main import app as base_app
 from inboard.app.fastapibase.main import app as fastapi_app
 from inboard.app.starlettebase.main import app as starlette_app
 
@@ -37,6 +38,12 @@ def basic_auth(
     assert os.getenv("BASIC_AUTH_USERNAME") == username
     assert os.getenv("BASIC_AUTH_PASSWORD") == password
     return username, password
+
+
+@pytest.fixture(scope="session")
+def client_asgi() -> TestClient:
+    """Instantiate test client classes."""
+    return TestClient(base_app)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -381,10 +381,8 @@ class TestStartServer:
     ) -> None:
         """Test `start.start_server` with Uvicorn managed by Gunicorn."""
         assert os.getenv("GUNICORN_CONF", str(gunicorn_conf_path))
-        monkeypatch.setenv("LOG_FORMAT", "gunicorn")
         monkeypatch.setenv("LOG_LEVEL", "debug")
         monkeypatch.setenv("PROCESS_MANAGER", "gunicorn")
-        assert os.getenv("LOG_FORMAT") == "gunicorn"
         assert os.getenv("LOG_LEVEL") == "debug"
         assert os.getenv("PROCESS_MANAGER") == "gunicorn"
         start.start_server(

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -65,6 +65,17 @@ class TestConfigureLogging:
             f"Logging dict config loaded from {logging_conf_module_path}."
         )
 
+    def test_configure_logging_module_incorrect(
+        self, mock_logger: logging.Logger
+    ) -> None:
+        with pytest.raises(ImportError):
+            start.configure_logging(logger=mock_logger, logging_conf="no.module.here")
+            import_error_msg = "Unable to import no.module.here."
+            logger_error_msg = "Error when configuring logging:"
+            mock_logger.debug.assert_called_once_with(  # type: ignore[attr-defined]
+                f"{logger_error_msg} {import_error_msg}."
+            )
+
     def test_configure_logging_tmp_file(
         self, logging_conf_tmp_file_path: Path, mock_logger: logging.Logger
     ) -> None:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,5 +1,18 @@
-from inboard import __version__
+from inboard import __version__, package_version
+
+current_version = "0.4.1"
+
+
+def test_package_version() -> None:
+    """Test package version calculation."""
+    assert package_version() == current_version
+
+
+def test_package_version_not_found() -> None:
+    """Test package version calculation when package is not installed."""
+    assert package_version(package="incorrect") == "Package not found."
 
 
 def test_version() -> None:
-    assert __version__ == "0.4.1"
+    """Test package version number."""
+    assert __version__ == current_version


### PR DESCRIPTION

## Description

PR #7 added test coverage measurement with [pytest-cov](https://github.com/pytest-dev/pytest-cov) and [Codecov](https://codecov.io/). The initial coverage measurement showed 86% unit test coverage.

This PR will increase the unit test coverage to 100%.

## Changes

- **Increase test coverage of inboard/`__init__.py`** (2a56650): 71% -> 100% coverage
- **Add unit tests for base ASGI app** (62d2e32, ed03219, 5e6af54): 0% -> 100% coverage
  - Add unit tests for base ASGI app endpoints using Starlette TestClient
  - Update base ASGI app with `PROCESS_MANAGER` environment variable
  - Verify that `PROCESS_MANAGER` environment variable is set to either `"gunicorn"` or `"uvicorn"`
  - Add unit test for exception when using inappropriate `PROCESS_MANAGER`
  - Type-annotate base ASGI app instance as `Callable`
- **Increase test coverage of Starlette utilities** (c40a020): 93% -> 100% coverage
  - Generalize Starlette exception handling in inboard/app/utilities.py: Exceptions are passed to inboard/app/starlettebase/main.py and handled by `on_auth_error()`.
  - Add test method to verify Starlette exception message returned by _inboard/app/starlettebase/main.py_
- **Increase test coverage of start.py** (ca4eacd): 89% -> 100% coverage
  - Remove `ImportError` conditional from `start.configure_logging()`: Python will raise an `ImportError` automatically in this case.
  - Add test method for incorrect logging module path to `test_start.py`
  - Remove exception handling from `start.run_pre_start_script`: Don't yet have a test case in which an exception would be raised.
  - Condense `__main__` block: Helps avoid replicate method calls when running `start.py`. Previously, some methods were running multiple times (such as `start.configure_logging`).
  - Add `pragma: no cover` comments to start.py `__main__` block: Methods are tested separately.
- **Increase test coverage of Gunicorn conf** (1275ac4, c6e04dc, cd7604c): 84% -> 100% coverage
  - Update `test_start.py` for default Gunicorn config: Test default configuration and custom configuration with separate test methods.
  - Streamline Gunicorn config logging: As in tiangolo/uvicorn-gunicorn-docker, the `gunicorn_conf.py` had been configured to print a JSON dump of the custom Gunicorn configuration. This is unnecessary, because Gunicorn already outputs its configuration to the logger when `LOG_LEVEL=debug` is used, so the JSON dump will be removed.
  - Remove exception handling when loading `logconfig_dict` in `gunicorn_conf.py`: The `start.configure_logging` method has its own exception handling.
  - Use same syntax when calculating `max_workers` and `workers_per_core` in `gunicorn_conf.py`
  - Add test method to `test_start.py` to check worker configuration
- **Update docs** (801dfdc, 2a74775, 090e15a, 24c6738)

## Related

br3ndonland/inboard#4
br3ndonland/inboard#7
br3ndonland/inboard@5b9706f
br3ndonland/inboard@397638e
br3ndonland/inboard@b0a36de
br3ndonland/inboard@735618a
br3ndonland/inboard@3906b3d
br3ndonland/inboard@92e6b68
br3ndonland/inboard@735618a

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
