### PR TITLE
Improve testing of server configuration

### DIFF
--- a/inboard/app/base/main.py
+++ b/inboard/app/base/main.py
@@ -24,7 +24,7 @@ class App:
             }
         )
         version = f"{sys.version_info.major}.{sys.version_info.minor}"
-        process_manager = os.getenv("PROCESS_MANAGER")
+        process_manager = os.getenv("PROCESS_MANAGER", "gunicorn")
         if process_manager not in ["gunicorn", "uvicorn"]:
             raise NameError("Process manager needs to be either uvicorn or gunicorn.")
         server = "Uvicorn" if process_manager == "uvicorn" else "Uvicorn, Gunicorn,"

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -93,7 +93,7 @@ class TestConfigureGunicorn:
         cores: int = multiprocessing.cpu_count()
         assert gunicorn_conf.calculate_workers(
             None, "2", str(os.getenv("WORKERS_PER_CORE")), cores=cores
-        ) == int(cores * 0.5)
+        ) == max(int(cores * 0.5), 2)
 
 
 class TestConfigureLogging:

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -22,14 +22,17 @@ class TestConfPaths:
         assert start.set_conf_path("gunicorn") == str(gunicorn_conf_path)
 
     def test_set_custom_conf_path_gunicorn(
-        self, gunicorn_conf_path_tmp: Path, monkeypatch: MonkeyPatch, tmp_path: Path
+        self,
+        gunicorn_conf_tmp_file_path: Path,
+        monkeypatch: MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         """Set path to custom temporary Gunicorn configuration file."""
-        monkeypatch.setenv("GUNICORN_CONF", str(gunicorn_conf_path_tmp))
-        assert os.getenv("GUNICORN_CONF") == str(gunicorn_conf_path_tmp)
-        assert f"{tmp_path}/gunicorn_conf.py" in str(gunicorn_conf_path_tmp)
-        assert "logging" not in str(gunicorn_conf_path_tmp)
-        assert start.set_conf_path("gunicorn") == str(gunicorn_conf_path_tmp)
+        monkeypatch.setenv("GUNICORN_CONF", str(gunicorn_conf_tmp_file_path))
+        assert os.getenv("GUNICORN_CONF") == str(gunicorn_conf_tmp_file_path)
+        assert "/gunicorn_conf.py" in str(gunicorn_conf_tmp_file_path)
+        assert "logging" not in str(gunicorn_conf_tmp_file_path)
+        assert start.set_conf_path("gunicorn") == str(gunicorn_conf_tmp_file_path)
 
     def test_set_incorrect_conf_path(self, monkeypatch: MonkeyPatch) -> None:
         """Set path to non-existent file and raise an error."""
@@ -404,14 +407,14 @@ class TestStartServer:
     def test_start_server_uvicorn_gunicorn_custom_config(
         self,
         app_module: str,
-        gunicorn_conf_path: Path,
+        gunicorn_conf_tmp_file_path: Path,
         logging_conf_dict: Dict[str, Any],
         mock_logger: logging.Logger,
         mocker: MockerFixture,
         monkeypatch: MonkeyPatch,
     ) -> None:
         """Test `start.start_server` with Uvicorn managed by Gunicorn."""
-        assert os.getenv("GUNICORN_CONF", str(gunicorn_conf_path))
+        assert os.getenv("GUNICORN_CONF") == str(gunicorn_conf_tmp_file_path)
         monkeypatch.setenv("LOG_FORMAT", "gunicorn")
         monkeypatch.setenv("LOG_LEVEL", "debug")
         monkeypatch.setenv("MAX_WORKERS", "1")

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -494,26 +494,12 @@ class TestStartServer:
         )
         monkeypatch.setenv("LOG_FORMAT", "gunicorn")
         monkeypatch.setenv("LOG_LEVEL", "debug")
-        monkeypatch.setenv("MAX_WORKERS", "1")
         monkeypatch.setenv("PROCESS_MANAGER", "gunicorn")
-        monkeypatch.setenv("WEB_CONCURRENCY", "4")
-        monkeypatch.setenv("WORKERS_PER_CORE", "0.5")
         assert gunicorn_conf_tmp_file_path.parent.exists()
         assert os.getenv("GUNICORN_CONF") == str(gunicorn_conf_tmp_file_path)
         assert os.getenv("LOG_FORMAT") == "gunicorn"
         assert os.getenv("LOG_LEVEL") == "debug"
-        assert os.getenv("MAX_WORKERS") == "1"
         assert os.getenv("PROCESS_MANAGER") == "gunicorn"
-        assert os.getenv("WEB_CONCURRENCY") == "4"
-        assert os.getenv("WORKERS_PER_CORE") == "0.5"
-        assert (
-            gunicorn_conf.calculate_workers(
-                str(os.getenv("MAX_WORKERS")),
-                str(os.getenv("WEB_CONCURRENCY")),
-                str(os.getenv("WORKERS_PER_CORE")),
-            )
-            == 1
-        )
         mock_run = mocker.patch("subprocess.run", autospec=True)
         start.start_server(
             str(os.getenv("PROCESS_MANAGER")),


### PR DESCRIPTION

## Description

Unit test coverage is at 100%, but testing doesn't stop there. It is still important to test that the Uvicorn and Gunicorn servers are being properly configured with environment variables and configuration files. This PR will provide improvements to the unit tests for the Uvicorn and Gunicorn servers, while maintaining test coverage at 100%.

## Changes

### Gunicorn

- **Properly mock Gunicorn and Uvicorn processes** (9ddbc4b)
  - Add full process calls: verify that the server functions (`uvicorn.run` for Uvicorn, `subprocess.run` for Gunicorn) are called with expected arguments.
  - Add mock for `subprocess.run()`: similar to Uvicorn update in 3906b3d.
  - Provide Gunicorn with correct `worker_tmp_dir`: The Gunicorn server was previously exiting without need for a mock. However, this was actually because it couldn't find the hard-coded `worker_tmp_dir` (`/dev/shm`), as can be seen when invoking pytest with `pytest -vv --capture=sys`. The solution is to override the hard-coded `worker_tmp_dir` with `GUNICORN_CMD_ARGS="--worker-tmp-dir $DIR"`. Although the full Gunicorn module is not mocked here, it's a good practice to properly configure the Gunicorn server.
- **Improve Gunicorn performance auto-tuning** (02b249e)
  - The "auto-tuning" advertised in [tiangolo/uvicorn-gunicorn-docker](https://github.com/tiangolo/uvicorn-gunicorn-docker) is basically a few lines of the `gunicorn_conf.py` that determine the number of Gunicorn workers to run. It would be helpful to write some unit test cases for this feature, but without being in a separate unit, it is difficult to unit test in isolation.
  - This commit will refactor the performance auto-tuning into a function, `gunicorn_conf.calculate_workers`, and will add unit test cases to `test_start.py` to verify the resulting number of worker processes.
- **Clarify Gunicorn worker calculation in README** (2567156)

### General

- **Improve pytest fixtures for temporary paths** (c1a6f3a)
  - Ensure `Path()` is used for `shutil` arguments instead of string
  - Create temporary directory for Gunicorn with `tmp_path_factory`
  - Copy `gunicorn_conf.py` to temporary directory
  - Update `test_start.py` with new Gunicorn paths
- **Set default process manager for base ASGI app** (9d51de4)
  - 5e6af54 added a check for the `PROCESS_MANAGER` environment variable in `inboard/app/base/main.py`, but no default was set.
  - This commit will set Gunicorn as the default process manager, to avoid errors if `PROCESS_MANAGER` is not set.

## Related

br3ndonland/inboard@3906b3d
br3ndonland/inboard@cd7604c
br3ndonland/inboard#8
https://github.com/tiangolo/uvicorn-gunicorn-docker/releases/tag/0.3.0
tiangolo/uvicorn-gunicorn-docker#5
tiangolo/uvicorn-gunicorn-starlette-docker#4
tiangolo/uvicorn-gunicorn-fastapi-docker#6

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
