### PR TITLE
Update inboard for Poetry 1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/br3ndonland/inboard"
 LABEL org.opencontainers.image.title="inboard"
 LABEL org.opencontainers.image.url="https://github.com/users/br3ndonland/packages/container/package/inboard"
-ENV APP_MODULE=inboard.app.base.main:app POETRY_VIRTUALENVS_CREATE=false PYTHONPATH=/app
+ENV APP_MODULE=inboard.app.base.main:app POETRY_HOME=/opt/poetry POETRY_VIRTUALENVS_CREATE=false PYTHONPATH=/app
 COPY poetry.lock pyproject.toml /app/
 WORKDIR /app/
-RUN python -m pip install poetry && poetry install --no-dev --no-interaction --no-root -E fastapi
+RUN curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py && \
+  python get-poetry.py -y && . $POETRY_HOME/env && \
+  poetry install --no-dev --no-interaction --no-root -E fastapi
 COPY inboard /app/inboard
 CMD python /app/inboard/start.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,5 @@ minversion = "6.0"
 testpaths = ["tests"]
 
 [build-system]
-requires = ["poetry>=1.0.10"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION

## Description

[Poetry 1.1.0](https://github.com/python-poetry/poetry/releases/tag/1.1.0) is out! :tada: :clap: Among the notable changes is a move to [poetry-core](https://github.com/python-poetry/poetry-core) as the build backend.

This PR will update the _Dockerfile_ and _pyproject.toml_ for Poetry 1.1.0.

## Changes

- **Update Dockerfile for Poetry custom installer** (94424ab):
  - Installing Poetry via `pip` can lead to dependency conflicts, so the custom installer is recommended.
  - There have been some issues adding Poetry's binaries to the `$PATH` in Docker. A manual symlink was needed (`ln -s $POETRY_HOME/bin/poetry /usr/local/bin`).
  - Poetry now appears to be correctly added to the `$PATH` in Docker, so manual symlinking is no longer necessary.
  - It is not essential to set `$POETRY_HOME`, but it will be done here to ensure consistent installations. Without `$POETRY_HOME`, Poetry binaries will be in `$HOME/.poetry/env`.
- **Update pyproject.toml for Poetry 1.1.0** (58930cb)

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
