### PR TITLE
Support multiple Python versions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -16,8 +16,6 @@ jobs:
         python-version: [3.8, 3.9]
     env:
       POETRY_VIRTUALENVS_CREATE: false
-    outputs:
-      python-version: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -59,6 +57,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: [python]
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Log in to Docker registry
@@ -66,13 +67,13 @@ jobs:
       - name: Build Docker images
         run: |
           docker build . --rm --target base \
-            --build-arg PYTHON_VERSION=${{ needs.python.outputs.python-version }} \
-            --cache-from python:${{ needs.python.outputs.python-version }} \
+            --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+            --cache-from python:${{ matrix.python-version }} \
             -t ghcr.io/br3ndonland/inboard:base
-          docker build . --rm --target starlette --build-arg PYTHON_VERSION=${{ needs.python.outputs.python-version }} -t ghcr.io/br3ndonland/inboard:starlette
-          docker build . --rm --target fastapi --build-arg PYTHON_VERSION=${{ needs.python.outputs.python-version }} -t ghcr.io/br3ndonland/inboard:fastapi
+          docker build . --rm --target starlette --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t ghcr.io/br3ndonland/inboard:starlette
+          docker build . --rm --target fastapi --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t ghcr.io/br3ndonland/inboard:fastapi
       - name: Push Docker images with latest Python version to registry
-        if: needs.python.outputs.python-version == '3.9' && startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' && matrix.python-version == '3.9'
         run: |
           docker push ghcr.io/br3ndonland/inboard:base
           docker push ghcr.io/br3ndonland/inboard:starlette
@@ -80,12 +81,12 @@ jobs:
       - name: Add Python version tag to Docker images
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
         run: |
-          docker tag ghcr.io/br3ndonland/inboard:base ghcr.io/br3ndonland/inboard:base-python${{ needs.python.outputs.python-version }}
-          docker tag ghcr.io/br3ndonland/inboard:starlette ghcr.io/br3ndonland/inboard:starlette-python${{ needs.python.outputs.python-version }}
-          docker tag ghcr.io/br3ndonland/inboard:fastapi ghcr.io/br3ndonland/inboard:fastapi-python${{ needs.python.outputs.python-version }}
-          docker push ghcr.io/br3ndonland/inboard:base-python${{ needs.python.outputs.python-version }}
-          docker push ghcr.io/br3ndonland/inboard:starlette-python${{ needs.python.outputs.python-version }}
-          docker push ghcr.io/br3ndonland/inboard:fastapi-python${{ needs.python.outputs.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:base ghcr.io/br3ndonland/inboard:base-python${{ matrix.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:starlette ghcr.io/br3ndonland/inboard:starlette-python${{ matrix.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:fastapi ghcr.io/br3ndonland/inboard:fastapi-python${{ matrix.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:base-python${{ matrix.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:starlette-python${{ matrix.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:fastapi-python${{ matrix.python-version }}
       - name: Add Git tag to Docker images
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -93,15 +94,15 @@ jobs:
           docker tag ghcr.io/br3ndonland/inboard:base ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"
           docker tag ghcr.io/br3ndonland/inboard:starlette ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"
           docker tag ghcr.io/br3ndonland/inboard:fastapi ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"
-          docker tag ghcr.io/br3ndonland/inboard:base ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
-          docker tag ghcr.io/br3ndonland/inboard:starlette ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
-          docker tag ghcr.io/br3ndonland/inboard:fastapi ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:base ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"-python${{ matrix.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:starlette ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"-python${{ matrix.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:fastapi ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"-python${{ matrix.python-version }}
           docker push ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"
           docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"
           docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"
-          docker push ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
-          docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
-          docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"-python${{ matrix.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"-python${{ matrix.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"-python${{ matrix.python-version }}
       - name: Tag and push latest Docker image
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -16,6 +16,8 @@ jobs:
         python-version: [3.8, 3.9]
     env:
       POETRY_VIRTUALENVS_CREATE: false
+    outputs:
+      python-version: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -63,15 +65,27 @@ jobs:
         run: docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.PAT_GHCR }}
       - name: Build Docker images
         run: |
-          docker build . --rm --target base -t ghcr.io/br3ndonland/inboard:base --cache-from python:3.9
-          docker build . --rm --target starlette -t ghcr.io/br3ndonland/inboard:starlette
-          docker build . --rm --target fastapi -t ghcr.io/br3ndonland/inboard:fastapi
-      - name: Push Docker images to registry
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
+          docker build . --rm --target base \
+            --build-arg PYTHON_VERSION=${{ needs.python.outputs.python-version }} \
+            --cache-from python:${{ needs.python.outputs.python-version }} \
+            -t ghcr.io/br3ndonland/inboard:base
+          docker build . --rm --target starlette --build-arg PYTHON_VERSION=${{ needs.python.outputs.python-version }} -t ghcr.io/br3ndonland/inboard:starlette
+          docker build . --rm --target fastapi --build-arg PYTHON_VERSION=${{ needs.python.outputs.python-version }} -t ghcr.io/br3ndonland/inboard:fastapi
+      - name: Push Docker images with latest Python version to registry
+        if: needs.python.outputs.python-version == '3.9' && startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
         run: |
           docker push ghcr.io/br3ndonland/inboard:base
           docker push ghcr.io/br3ndonland/inboard:starlette
           docker push ghcr.io/br3ndonland/inboard:fastapi
+      - name: Add Python version tag to Docker images
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
+        run: |
+          docker tag ghcr.io/br3ndonland/inboard:base ghcr.io/br3ndonland/inboard:base-python${{ needs.python.outputs.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:starlette ghcr.io/br3ndonland/inboard:starlette-python${{ needs.python.outputs.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:fastapi ghcr.io/br3ndonland/inboard:fastapi-python${{ needs.python.outputs.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:base-python${{ needs.python.outputs.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:starlette-python${{ needs.python.outputs.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:fastapi-python${{ needs.python.outputs.python-version }}
       - name: Add Git tag to Docker images
         if: startsWith(github.ref, 'refs/tags/')
         run: |
@@ -79,9 +93,15 @@ jobs:
           docker tag ghcr.io/br3ndonland/inboard:base ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"
           docker tag ghcr.io/br3ndonland/inboard:starlette ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"
           docker tag ghcr.io/br3ndonland/inboard:fastapi ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"
+          docker tag ghcr.io/br3ndonland/inboard:base ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:starlette ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
+          docker tag ghcr.io/br3ndonland/inboard:fastapi ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
           docker push ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"
           docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"
           docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"
+          docker push ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
+          docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"-python${{ needs.python.outputs.python-version }}
       - name: Tag and push latest Docker image
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -5,19 +5,22 @@ on:
   push:
     branches: [develop, master]
     tags:
-      - "[0-9v]+.[0-9]+.[0-9a-z]+"
+      - "[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 
 jobs:
   python:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
     env:
       POETRY_VIRTUALENVS_CREATE: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Set up Poetry cache for Python dependencies
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Linux')

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -9,13 +9,16 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
     env:
       POETRY_VIRTUALENVS_CREATE: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Set up Poetry cache for Python dependencies
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Linux')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9]
     env:
       POETRY_VIRTUALENVS_CREATE: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Set up Poetry cache for Python dependencies
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Linux')

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.9 AS base
+ARG PYTHON_VERSION=3.9
+FROM python:${PYTHON_VERSION} AS base
 LABEL org.opencontainers.image.authors="Brendon Smith <br3ndonland@protonmail.com>"
 LABEL org.opencontainers.image.description="Docker images to power your Python APIs and help you ship faster."
 LABEL org.opencontainers.image.licenses="MIT"

--- a/README.md
+++ b/README.md
@@ -50,21 +50,32 @@ This repo provides [Docker images](https://github.com/users/br3ndonland/packages
 
 ### Pull images
 
-Docker images are stored in [GitHub Container Registry](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry) (GHCR), which is a Docker registry like Docker Hub. Public Docker images can be pulled anonymously from `ghcr.io`.
+Docker images are stored in [GitHub Container Registry](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry) (GHCR), which is a Docker registry like Docker Hub. Public Docker images can be pulled anonymously from `ghcr.io`. Simply running `docker pull ghcr.io/br3ndonland/inboard` will pull the latest FastAPI image (Docker uses the `latest` tag by default). If specific versions of inboard or Python are desired, append the version numbers to the specified Docker tags as shown below _(new in inboard version 0.6.0)_.
 
 ```sh
-# Pull most recent version of each image
+# Pull latest FastAPI image
+docker pull ghcr.io/br3ndonland/inboard
+
+# Pull latest version of each image
 docker pull ghcr.io/br3ndonland/inboard:base
 docker pull ghcr.io/br3ndonland/inboard:fastapi
 docker pull ghcr.io/br3ndonland/inboard:starlette
 
 # Pull image from specific release
-docker pull ghcr.io/br3ndonland/inboard:base-0.2.0
-docker pull ghcr.io/br3ndonland/inboard:fastapi-0.2.0
-docker pull ghcr.io/br3ndonland/inboard:starlette-0.2.0
-```
+docker pull ghcr.io/br3ndonland/inboard:base-0.6.0
+docker pull ghcr.io/br3ndonland/inboard:fastapi-0.6.0
+docker pull ghcr.io/br3ndonland/inboard:starlette-0.6.0
 
-The FastAPI image is also tagged with `latest`. Docker uses the `latest` tag by default, so simply running `docker pull ghcr.io/br3ndonland/inboard` will pull the FastAPI image.
+# Pull image with specific Python version
+docker pull ghcr.io/br3ndonland/inboard:base-python3.8
+docker pull ghcr.io/br3ndonland/inboard:fastapi-python3.8
+docker pull ghcr.io/br3ndonland/inboard:starlette-python3.8
+
+# Pull image from specific release and with specific Python version
+docker pull ghcr.io/br3ndonland/inboard:base-0.6.0-python3.8
+docker pull ghcr.io/br3ndonland/inboard:fastapi-0.6.0-python3.8
+docker pull ghcr.io/br3ndonland/inboard:starlette-0.6.0-python3.8
+```
 
 If authentication to GHCR is needed, follow the instructions [below](#configuring-docker-for-github-container-registry).
 


### PR DESCRIPTION
## Description

This project started with Python 3.8. Python 3.9 is now available. so the _Dockerfile_ and GitHub Actions workflows have been updated to Python 3.9.

It is helpful to retain support for Python 3.8, as some Python packages and software stacks have not yet been updated for Python 3.9. This PR will add support for multiple Python versions, starting with 3.8.

## Changes

- Add Python version matrices for GitHub Actions (1a7a5ad)
- Add Python version build argument to Dockerfile (69ebc5f)
- Build Docker images for multiple Python versions (dc8da18)
- Add info on specifying Python version to README (c14de7f)
- Use Python version matrix in Docker job (465c923)

## Related

br3ndonland/inboard@d9734b4
br3ndonland/inboard@6f01d75

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
