### PR TITLE
Improve separation between FastAPI and Starlette

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,14 @@ ENV APP_MODULE=inboard.app.main_base:app POETRY_HOME=/opt/poetry POETRY_VIRTUALE
 COPY poetry.lock pyproject.toml /app/
 WORKDIR /app/
 RUN curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py && \
-  python get-poetry.py -y && . $POETRY_HOME/env && \
-  poetry install --no-dev --no-interaction --no-root -E fastapi
+  python get-poetry.py -y && . $POETRY_HOME/env && poetry install --no-dev --no-interaction --no-root
 COPY inboard /app/inboard
 CMD python /app/inboard/start.py
 
 FROM base AS fastapi
-ENV APP_MODULE=inboard.app.main_fastapi:app
+ENV APP_MODULE=inboard.app.main_fastapi:app PATH=$POETRY_HOME/bin:$PATH
+RUN poetry install --no-dev --no-interaction --no-root -E fastapi
 
 FROM base AS starlette
-ENV APP_MODULE=inboard.app.main_starlette:app
+ENV APP_MODULE=inboard.app.main_starlette:app PATH=$POETRY_HOME/bin:$PATH
+RUN poetry install --no-dev --no-interaction --no-root -E starlette

--- a/inboard/app/main_fastapi.py
+++ b/inboard/app/main_fastapi.py
@@ -5,7 +5,7 @@ from typing import Dict
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from inboard.app.utilities import basic_auth
+from inboard.app.utilities_fastapi import basic_auth
 
 server = "Uvicorn" if bool(os.getenv("WITH_RELOAD")) else "Uvicorn, Gunicorn"
 version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"

--- a/inboard/app/main_starlette.py
+++ b/inboard/app/main_starlette.py
@@ -8,7 +8,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from inboard.app.utilities import BasicAuth
+from inboard.app.utilities_starlette import BasicAuth
 
 server = "Uvicorn" if bool(os.getenv("WITH_RELOAD")) else "Uvicorn, Gunicorn"
 version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"

--- a/inboard/app/utilities_fastapi.py
+++ b/inboard/app/utilities_fastapi.py
@@ -1,0 +1,22 @@
+import os
+from secrets import compare_digest
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+
+async def basic_auth(credentials: HTTPBasicCredentials = Depends(HTTPBasic())) -> str:
+    correct_username = compare_digest(
+        credentials.username, str(os.getenv("BASIC_AUTH_USERNAME", "test_username"))
+    )
+    correct_password = compare_digest(
+        credentials.password,
+        str(os.getenv("BASIC_AUTH_PASSWORD", "plunge-germane-tribal-pillar")),
+    )
+    if not (correct_username and correct_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return credentials.username

--- a/inboard/app/utilities_starlette.py
+++ b/inboard/app/utilities_starlette.py
@@ -3,8 +3,6 @@ import os
 from secrets import compare_digest
 from typing import Optional, Tuple
 
-from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from starlette.authentication import (
     AuthCredentials,
     AuthenticationBackend,
@@ -38,20 +36,3 @@ class BasicAuth(AuthenticationBackend):
             return AuthCredentials(["authenticated"]), SimpleUser(username)
         except Exception:
             raise
-
-
-def basic_auth(credentials: HTTPBasicCredentials = Depends(HTTPBasic())) -> str:
-    correct_username = compare_digest(
-        credentials.username, str(os.getenv("BASIC_AUTH_USERNAME", "test_username"))
-    )
-    correct_password = compare_digest(
-        credentials.password,
-        str(os.getenv("BASIC_AUTH_PASSWORD", "plunge-germane-tribal-pillar")),
-    )
-    if not (correct_username and correct_password):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Basic"},
-        )
-    return credentials.username

--- a/poetry.lock
+++ b/poetry.lock
@@ -111,7 +111,7 @@ python-versions = "*"
 
 [[package]]
 name = "fastapi"
-version = "0.61.2"
+version = "0.62.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 category = "main"
 optional = true
@@ -124,7 +124,7 @@ starlette = "0.13.6"
 [package.extras]
 all = ["requests (>=2.24.0,<3.0.0)", "aiofiles (>=0.5.0,<0.6.0)", "jinja2 (>=2.11.2,<3.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "itsdangerous (>=1.1.0,<2.0.0)", "pyyaml (>=5.3.1,<6.0.0)", "graphene (>=2.1.8,<3.0.0)", "ujson (>=3.0.0,<4.0.0)", "orjson (>=3.2.1,<4.0.0)", "email_validator (>=1.1.1,<2.0.0)", "uvicorn (>=0.11.5,<0.12.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)"]
 dev = ["python-jose[cryptography] (>=3.1.0,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "uvicorn (>=0.11.5,<0.12.0)", "graphene (>=2.1.8,<3.0.0)"]
-doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.5.0,<6.0.0)", "markdown-include (>=0.5.1,<0.6.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.2.0)", "typer (>=0.3.0,<0.4.0)", "typer-cli (>=0.0.9,<0.0.10)", "pyyaml (>=5.3.1,<6.0.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=6.1.4,<7.0.0)", "markdown-include (>=0.5.1,<0.6.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.2.0)", "typer (>=0.3.0,<0.4.0)", "typer-cli (>=0.0.9,<0.0.10)", "pyyaml (>=5.3.1,<6.0.0)"]
 test = ["pytest (==5.4.3)", "pytest-cov (==2.10.0)", "pytest-asyncio (>=0.14.0,<0.15.0)", "mypy (==0.782)", "flake8 (>=3.8.3,<4.0.0)", "black (==19.10b0)", "isort (>=5.0.6,<6.0.0)", "requests (>=2.24.0,<3.0.0)", "httpx (>=0.14.0,<0.15.0)", "email_validator (>=1.1.1,<2.0.0)", "sqlalchemy (>=1.3.18,<2.0.0)", "peewee (>=3.13.3,<4.0.0)", "databases[sqlite] (>=0.3.2,<0.4.0)", "orjson (>=3.2.1,<4.0.0)", "async_exit_stack (>=1.0.1,<2.0.0)", "async_generator (>=1.10,<2.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "aiofiles (>=0.5.0,<0.6.0)", "flask (>=1.1.2,<2.0.0)"]
 
 [[package]]
@@ -574,7 +574,7 @@ starlette = ["starlette"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "3c96ced6ec7bb780a5b8c1ab5384521420496f23c44f6465692e642ed5609198"
+content-hash = "309704d4938f361ba41cf4b0851f03d3f1e194a95bcaf164f0f69aed69fd2167"
 
 [metadata.files]
 appdirs = [
@@ -653,8 +653,8 @@ distlib = [
     {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
 ]
 fastapi = [
-    {file = "fastapi-0.61.2-py3-none-any.whl", hash = "sha256:8c8517680a221e69eb34073adf46c503092db2f24845b7bdc7f85b54f24ff0df"},
-    {file = "fastapi-0.61.2.tar.gz", hash = "sha256:9e0494fcbba98f85b8cc9b2606bb6b625246e1b12f79ca61f508b0b00843eca6"},
+    {file = "fastapi-0.62.0-py3-none-any.whl", hash = "sha256:62074dd38541d9d7245f3aacbbd0d44340c53d56186c9b249d261a18dad4874b"},
+    {file = "fastapi-0.62.0.tar.gz", hash = "sha256:8f4c64cd9cea67fb7dd175ca5015961efa572b9f43a8731014dac8929d86225f"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -574,7 +574,7 @@ starlette = ["starlette"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "309704d4938f361ba41cf4b0851f03d3f1e194a95bcaf164f0f69aed69fd2167"
+content-hash = "618773c7eb3a19e64c0167ff4a964f284e9381b79ea82089810dc7bccd464d4d"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 python = "^3.8"
 gunicorn = "^20"
 uvicorn = {version = "^0.12.1", extras = ["standard"]}
-fastapi = {version = "^0.61", optional = true}
+fastapi = {version = "^0.62", optional = true}
 starlette = {version = "^0.13", optional = true}
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ python = "^3.8"
 gunicorn = "^20"
 uvicorn = {version = "^0.12.1", extras = ["standard"]}
 fastapi = {version = "^0.62", optional = true}
-starlette = {version = "^0.13", optional = true}
+starlette = {version = "0.13.6 || ^0.14", optional = true}
 
 [tool.poetry.dev-dependencies]
 black = {version = "20.8b1", allow-prereleases = true}


### PR DESCRIPTION
## Description

FastAPI depends on Starlette. For simplicity, inboard was set up to install FastAPI from the get-go, because installing FastAPI will also install Starlette. However, this means that the Starlette application is dependent on FastAPI, which is sort of backwards. Within the inboard source code, the utilities module contained the HTTP Basic Auth implementations for Starlette and FastAPI, but because FastAPI was imported into that module, it also meant that the Starlette application required FastAPI in order to import the module.

This PR will improve the separation of concerns between FastAPI and Starlette, so that the FastAPI and Starlette features are independent, and the Starlette application can run without installing FastAPI.

## Changes

- Separate FastAPI and Starlette utilities (a9d5617)
- Separate FastAPI and Starlette Docker installs (7f36165)
- Upgrade to [FastAPI 0.62](https://github.com/tiangolo/fastapi/releases) (3ec8dd4)
- Enable [Starlette 0.14](https://github.com/encode/starlette/releases) (61960ca)

## FastAPI 0.62.0 and Starlette 0.14 have mutually incompatible version constraints

As far as I can tell, it's not possible to install both FastAPI 0.62 and Starlette 0.14 in the same Poetry project. FastAPI 0.62.0 has Starlette pinned at 0.13.6, and attempts to add Starlette 0.14 raise a Poetry `SolverProblemError` (on Poetry 1.1.4):

```text
❯ poetry add starlette@'^0.14'

Updating dependencies
Resolving dependencies... (0.1s)

  SolverProblemError

  Because fastapi (0.62.0) depends on starlette (0.13.6)
  and no versions of fastapi match >0.62,<0.63, fastapi (>=0.62,<0.63) requires starlette (0.13.6).
  So, because inboard depends on both fastapi (^0.62) and starlette (^0.14), version solving failed.

  at ~/.poetry/lib/poetry/puzzle/solver.py:241 in _solve
      237│             packages = result.packages
      238│         except OverrideNeeded as e:
      239│             return self.solve_in_compatibility_mode(e.overrides, use_latest=use_latest)
      240│         except SolveFailure as e:
    → 241│             raise SolverProblemError(e)
      242│
      243│         results = dict(
      244│             depth_first_search(
      245│                 PackageNode(self._package, packages), aggregate_package_nodes
```

I would be open to having FastAPI 0.62 and Starlette 0.14 be separate sets of dependencies, but even if only one set of extras is installed (`poetry install -E starlette`), Poetry appears to resolve all the dependencies together, so the environment will still end up with Starlette 0.13.6.

### Docker partial solution

In Docker, FastAPI can be removed from the Poetry project prior to installing Starlette, so that Starlette 0.14 can be installed.

```dockerfile
FROM base AS starlette
ENV APP_MODULE=inboard.app.main_starlette:app PATH=$POETRY_HOME/bin:$PATH
RUN poetry remove fastapi && poetry add starlette@^0.14 --optional && \
  poetry install --no-dev --no-interaction --no-root -E starlette
```

This looks like it would work well, but for some reason, running `poetry remove fastapi` installs all the dev dependencies, then `poetry install --no-dev` removes them. Totally counterintuitive and inefficient.

<details><summary>Docker build logs</summary>

```text
Step 18/22 : FROM base AS starlette
 ---> edf48237e383
Step 19/22 : ENV APP_MODULE=inboard.app.main_starlette:app PATH=$POETRY_HOME/bin:$PATH
 ---> Using cache
 ---> 7548d5f13393
Step 20/22 : RUN poetry remove fastapi
 ---> Running in 46e65064e023
Skipping virtualenv creation, as specified in config file.
Updating dependencies
Resolving dependencies...

Writing lock file

Package operations: 37 installs, 0 updates, 0 removals

  • Installing pyparsing (2.4.7)
  • Installing appdirs (1.4.4)
  • Installing attrs (20.3.0)
  • Installing distlib (0.3.1)
  • Installing filelock (3.0.12)
  • Installing iniconfig (1.1.1)
  • Installing packaging (20.8)
  • Installing pluggy (0.13.1)
  • Installing py (1.10.0)
  • Installing six (1.15.0)
  • Installing toml (0.10.2)
  • Installing certifi (2020.12.5)
  • Installing cfgv (3.2.0)
  • Installing chardet (4.0.0)
  • Installing coverage (5.3)
  • Installing idna (2.10)
  • Installing identify (1.5.10)
  • Installing mccabe (0.6.1)
  • Installing mypy-extensions (0.4.3)
  • Installing nodeenv (1.5.0)
  • Installing pathspec (0.8.1)
  • Installing pycodestyle (2.6.0)
  • Installing pyflakes (2.2.0)
  • Installing pytest (6.2.1)
  • Installing regex (2020.11.13)
  • Installing typed-ast (1.4.1)
  • Installing typing-extensions (3.7.4.3)
  • Installing urllib3 (1.26.2)
  • Installing virtualenv (20.2.2)
  • Installing black (20.8b1)
  • Installing flake8 (3.8.4)
  • Installing isort (5.6.4)
  • Installing mypy (0.790)
  • Installing pre-commit (2.9.3)
  • Installing pytest-cov (2.10.1)
  • Installing pytest-mock (3.4.0)
  • Installing requests (2.25.1)
Removing intermediate container 46e65064e023
 ---> 5b90fecdeca0
Step 21/22 : RUN poetry add starlette@^0.14
 ---> Running in 91d3d1cee3f0
Skipping virtualenv creation, as specified in config file.

Updating dependencies
Resolving dependencies...

Writing lock file

Package operations: 1 install, 0 updates, 0 removals

  • Installing starlette (0.14.1)
Removing intermediate container 91d3d1cee3f0
 ---> 76b7b3213c93
Step 22/22 : RUN poetry install --no-dev --no-interaction --no-root -E starlette
 ---> Running in 24aa553a5052
Skipping virtualenv creation, as specified in config file.
Installing dependencies from lock file

Package operations: 0 installs, 0 updates, 37 removals

  • Removing appdirs (1.4.4)
  • Removing attrs (20.3.0)
  • Removing black (20.8b1)
  • Removing certifi (2020.12.5)
  • Removing cfgv (3.2.0)
  • Removing chardet (4.0.0)
  • Removing coverage (5.3)
  • Removing distlib (0.3.1)
  • Removing filelock (3.0.12)
  • Removing flake8 (3.8.4)
  • Removing identify (1.5.10)
  • Removing idna (2.10)
  • Removing iniconfig (1.1.1)
  • Removing isort (5.6.4)
  • Removing mccabe (0.6.1)
  • Removing mypy (0.790)
  • Removing mypy-extensions (0.4.3)
  • Removing nodeenv (1.5.0)
  • Removing packaging (20.8)
  • Removing pathspec (0.8.1)
  • Removing pluggy (0.13.1)
  • Removing pre-commit (2.9.3)
  • Removing py (1.10.0)
  • Removing pycodestyle (2.6.0)
  • Removing pyflakes (2.2.0)
  • Removing pyparsing (2.4.7)
  • Removing pytest (6.2.1)
  • Removing pytest-cov (2.10.1)
  • Removing pytest-mock (3.4.0)
  • Removing regex (2020.11.13)
  • Removing requests (2.25.1)
  • Removing six (1.15.0)
  • Removing toml (0.10.2)
  • Removing typed-ast (1.4.1)
  • Removing typing-extensions (3.7.4.3)
  • Removing urllib3 (1.26.2)
  • Removing virtualenv (20.2.2)
Removing intermediate container 24aa553a5052
 ---> 3b67425ed943
Successfully built 3b67425ed943
Successfully tagged localhost/br3ndonland/inboard:starlette

```

</details>

### Poetry partial solution

Install the Starlette version pinned by FastAPI (0.13.6), but add a Poetry union operator (`||`) so upgrading to Starlette 0.14 is at least possible in the future. The order of the union doesn't seem to matter.

`starlette = {version = "0.13.6 || ^0.14", optional = true}`

Union operators may not work properly with [multiple-constraint dependencies](https://python-poetry.org/docs/dependency-specification/#multiple-constraints-dependencies) (python-poetry/poetry#2340).

### Other possible Poetry solutions

There are some other related Poetry features, but they don't fully address this use case.

#### Specifying multiple version constraints with `python` or `markers`

"Markers" are constraints used when installing Python packages. They are mostly for system-level constraints, like operating system and Python version, and don't seem like they can be used to specify groups of dependencies. There's no marker for FastAPI, so markers don't satisfy the use case here.

Markers are supported by Poetry, though they are only [partially documented](https://python-poetry.org/docs/dependency-specification/#using-environment-markers). If you would like to learn more about markers, and don't mind confusing yourself, you can read through the opaque "parsley grammar" in [PEP 508](https://www.python.org/dev/peps/pep-0508/).

Related:

- python-poetry/poetry#738
- python-poetry/poetry#2480
- python-poetry/poetry#3347

<details><summary><em>pyproject.toml</em> examples with multiple constraints</summary>

Based on [tests/fixtures/project_with_multi_constraints_dependency/pyproject.toml](https://github.com/python-poetry/poetry/blob/master/tests/fixtures/project_with_multi_constraints_dependency/pyproject.toml).

```toml
# pyproject.toml without extras
[tool.poetry]
name = "project-with-multi-constraints-dependency"
version = "1.2.3"
description = "This is a description"
authors = ["Your Name <you@example.com>"]
license = "MIT"

[tool.poetry.dependencies]
python = "*"
pendulum = [
    { version = "^1.5", python = "<3.4" },
    { version = "^2.0", python = "^3.4" }
]

[tool.poetry.dev-dependencies]
```

```toml
# pyproject.toml with extras
[tool.poetry]
name = "project-with-multi-constraints-dependency"
version = "1.2.3"
description = "This is a description"
authors = ["Your Name <you@example.com>"]
license = "MIT"

[tool.poetry.dependencies]
python = "*"
pendulum = [
    {version = "^1.5", python = "<3.4", optional = true},
    {version = "^2.0", python = "^3.4", optional = true}
]

[tool.poetry.dev-dependencies]

[tool.poetry.extras]
time = ["pendulum"]
```

</details>

#### Using a wildcard in the `tool.poetry.dependencies` section, and then using `tool.poetry.extras` to specify versions

I tried this out, but it doesn't work. Specifying version constraints for extras in _pyproject.toml_, then running `poetry update`, deletes the extras from _poetry.lock_.

<details><summary><em>pyproject.toml</em> example with version constraints in extras</summary>

```toml
# pyproject.toml with version constraints in extras
[tool.poetry]
name = "poetrydependencyversions"
version = "0.0.1"
description = "Installing multiple versions of a dependency with Poetry."
authors = ["Your Name <you@example.com>"]
license = "MIT"

[tool.poetry.dependencies]
python = "^3.8"
fastapi = {version = "*", optional = true}
starlette = {version = "*", optional = true}

[tool.poetry.extras]
# these version constraints don't work as expected
fastapi = ["starlette ==0.13.6", "fastapi"]
starlette = ["starlette >=0.14.0"]

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"

```

</details>

Confusingly, running `poetry check` over the _pyproject.toml_ returns an "All set!" success message, even though it's clearly not behaving as expected.

This issue may be addressed in upcoming releases (python-poetry/poetry-core#103).
