### PR TITLE
Implement Uvicorn reload_dirs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "python",
       "request": "launch",
       "stopOnEntry": false,
-      "pythonPath": "${command:python.interpreterPath}",
+      "python": "${command:python.interpreterPath}",
       "module": "inboard.start",
       "env": {
         "APP_MODULE": "inboard.app.main_fastapi:app",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,7 @@
         "LOG_LEVEL": "debug",
         "PORT": "1025",
         "PROCESS_MANAGER": "uvicorn",
+        "RELOAD_DIRS": "inboard",
         "WITH_RELOAD": "true"
       },
       "console": "integratedTerminal",

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Details on the `docker run` command:
   - `LOG_COLORS`
   - `LOG_FORMAT`
   - `LOG_LEVEL`
+  - `RELOAD_DIRS`
+  - `WITH_RELOAD`
 - `-v $(pwd)/package:/app/package`: the specified directory (`/path/to/repo/package` in this example) will be [mounted as a volume](https://docs.docker.com/engine/reference/run/#volume-shared-filesystems) inside of the container at `/app/package`. When files in the working directory change, Docker and Uvicorn will sync the files to the running Docker container.
 
 Hit an API endpoint:
@@ -287,6 +289,15 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
       -e GUNICORN_CMD_ARGS="--keyfile=/secrets/key.pem --certfile=/secrets/cert.pem" \
       -e PORT=443 myimage
     ```
+- `WITH_RELOAD`: Configure the [Uvicorn auto-reload setting](https://www.uvicorn.org/settings/).
+  - Default: `"false"` (don't auto-reload when files change)
+  - Custom: `"true"` (watch files with [watchgod](https://github.com/samuelcolvin/watchgod) and auto-reload when files change). Auto-reloading is useful for local development. [Watchgod](https://github.com/samuelcolvin/watchgod) was added as an optional dependency in [Uvicorn 0.11.4](https://github.com/encode/uvicorn/releases/tag/0.11.4), and is included with inboard.
+- `RELOAD_DIRS`: Directories and files to watch for changes with [watchgod](https://github.com/samuelcolvin/watchgod), formatted as comma-separated string. On the command-line, this [Uvicorn setting](https://www.uvicorn.org/settings/) is configured by passing `--reload-dir`, and can be passed multiple times, with one directory each. However, when running Uvicorn programmatically, `uvicorn.run` accepts a list of strings (`uvicorn.run(reload_dirs=["dir1", "dir2"])`), so inboard will parse the environment variable, send the list to Uvicorn, and watchgod will watch each directory or file specified.
+  - Default: watch all directories under project root.
+  - Custom:
+    - `"inboard"` (one directory)
+    - `"inboard, tests"` (two directories)
+    - `"inboard, tests, Dockerfile"` (two directories and a file)
 
 ### Logging
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -505,7 +505,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.12.3"
+version = "0.13.1"
 description = "The lightning-fast ASGI server."
 category = "main"
 optional = false
@@ -574,7 +574,7 @@ starlette = ["starlette"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "618773c7eb3a19e64c0167ff4a964f284e9381b79ea82089810dc7bccd464d4d"
+content-hash = "8f11f79ecd17e59387f91d9d55984c1d865c0c26407a4134b9241fe24e132d6f"
 
 [metadata.files]
 appdirs = [
@@ -918,8 +918,8 @@ urllib3 = [
     {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
 ]
 uvicorn = [
-    {file = "uvicorn-0.12.3-py3-none-any.whl", hash = "sha256:562ef6aaa8fa723ab6b82cf9e67a774088179d0ec57cb17e447b15d58b603bcf"},
-    {file = "uvicorn-0.12.3.tar.gz", hash = "sha256:5836edaf4d278fe67ba0298c0537bdb6398cf359eb644f79e6500ca1aad232b3"},
+    {file = "uvicorn-0.13.1-py3-none-any.whl", hash = "sha256:6fcce74c00b77d4f4b3ed7ba1b2a370d27133bfdb46f835b7a76dfe0a8c110ae"},
+    {file = "uvicorn-0.13.1.tar.gz", hash = "sha256:2a7b17f4d9848d6557ccc2274a5f7c97f1daf037d130a0c6918f67cd9bc8cdf5"},
 ]
 uvloop = [
     {file = "uvloop-0.14.0-cp35-cp35m-macosx_10_11_x86_64.whl", hash = "sha256:08b109f0213af392150e2fe6f81d33261bb5ce968a288eb698aad4f46eb711bd"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -403,6 +403,17 @@ pytest = ">=5.0"
 dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
+name = "pytest-timeout"
+version = "1.4.2"
+description = "py.test plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = ">=3.6.0"
+
+[[package]]
 name = "python-dotenv"
 version = "0.15.0"
 description = "Add .env support to your django/flask apps in development and deployments"
@@ -574,7 +585,7 @@ starlette = ["starlette"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "8f11f79ecd17e59387f91d9d55984c1d865c0c26407a4134b9241fe24e132d6f"
+content-hash = "d0818aafc37750a9eabff52444f69ee6788fc4d686192a5219e7141a42247ef5"
 
 [metadata.files]
 appdirs = [
@@ -797,6 +808,10 @@ pytest-cov = [
 pytest-mock = [
     {file = "pytest-mock-3.4.0.tar.gz", hash = "sha256:c3981f5edee6c4d1942250a60d9b39d38d5585398de1bfce057f925bdda720f4"},
     {file = "pytest_mock-3.4.0-py3-none-any.whl", hash = "sha256:c0fc979afac4aaba545cbd01e9c20736eb3fefb0a066558764b07d3de8f04ed3"},
+]
+pytest-timeout = [
+    {file = "pytest-timeout-1.4.2.tar.gz", hash = "sha256:20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76"},
+    {file = "pytest_timeout-1.4.2-py2.py3-none-any.whl", hash = "sha256:541d7aa19b9a6b4e475c759fd6073ef43d7cdc9a92d95644c260076eb257a063"},
 ]
 python-dotenv = [
     {file = "python-dotenv-0.15.0.tar.gz", hash = "sha256:587825ed60b1711daea4832cf37524dfd404325b7db5e25ebe88c495c9f807a0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 gunicorn = "^20"
-uvicorn = {version = "^0.12.1", extras = ["standard"]}
+uvicorn = {version = "^0.13", extras = ["standard"]}
 fastapi = {version = "^0.62", optional = true}
 starlette = {version = "0.13.6 || ^0.14", optional = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ pre-commit = "^2.8"
 pytest = "^6.2"
 pytest-cov = "^2.10"
 pytest-mock = "^3.3"
+pytest-timeout = "^1.4"
 requests = "^2.24"
 
 [tool.poetry.extras]

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -416,6 +416,7 @@ class TestStartServer:
             "inboard.app.main_starlette:app",
         ],
     )
+    @pytest.mark.timeout(2)
     def test_start_server_uvicorn(
         self,
         app_module: str,
@@ -458,6 +459,7 @@ class TestStartServer:
     @pytest.mark.parametrize(
         "reload_dirs", ["inboard", "inboard,tests", "inboard, tests"]
     )
+    @pytest.mark.timeout(2)
     def test_start_server_uvicorn_reload_dirs(
         self,
         app_module: str,
@@ -505,6 +507,7 @@ class TestStartServer:
             "inboard.app.main_starlette:app",
         ],
     )
+    @pytest.mark.timeout(2)
     def test_start_server_uvicorn_gunicorn(
         self,
         app_module: str,
@@ -553,6 +556,7 @@ class TestStartServer:
             "inboard.app.main_starlette:app",
         ],
     )
+    @pytest.mark.timeout(2)
     def test_start_server_uvicorn_gunicorn_custom_config(
         self,
         app_module: str,
@@ -604,6 +608,7 @@ class TestStartServer:
             "inboard.app.main_starlette:app",
         ],
     )
+    @pytest.mark.timeout(2)
     def test_start_server_uvicorn_incorrect_process_manager(
         self,
         app_module: str,

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -596,32 +596,6 @@ class TestStartServer:
             ]
         )
 
-    def test_start_server_uvicorn_incorrect_module(
-        self,
-        logging_conf_dict: Dict[str, Any],
-        mock_logger: logging.Logger,
-        mocker: MockerFixture,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Test `start.start_server` with Uvicorn and an incorrect module path."""
-        with pytest.raises(ModuleNotFoundError):
-            monkeypatch.setenv("LOG_LEVEL", "debug")
-            monkeypatch.setenv("WITH_RELOAD", "false")
-            start.start_server(
-                "uvicorn",
-                app_module="incorrect.base.main:app",
-                logger=mock_logger,
-                logging_conf_dict=logging_conf_dict,
-            )
-            logger_error_msg = "Error when starting server with start script:"
-            module_error_msg = "No module named incorrect.base.main:app"
-            mock_logger.debug.assert_has_calls(  # type: ignore[attr-defined]
-                calls=[
-                    mocker.call("Running Uvicorn without Gunicorn."),
-                    mocker.call(f"{logger_error_msg} {module_error_msg}"),
-                ]
-            )
-
     @pytest.mark.parametrize(
         "app_module",
         [


### PR DESCRIPTION
## Description

This PR will implement the Uvicorn `reload_dirs` setting, enabling file watching and hot-reloading with [watchgod](https://github.com/samuelcolvin/watchgod) for development.

[watchgod](https://github.com/samuelcolvin/watchgod) is a filesystem watcher that was added in [Uvicorn 0.11.4](https://github.com/encode/uvicorn/releases/tag/0.11.4). The directories to watch can be configured from the command-line with the `--reload-dir` argument. Multiple `--reload-dir`s can be used, with one directory specified each time.

The Uvicorn docs say, "If you're running using programmatically, using `uvicorn.run(...)`, then use equivalent keyword arguments," but this is not quite accurate for `--reload-dir`. The programmatic equivalent is `reload_dirs`, which accepts `List[str]`.

To implement `reload_dirs` in a customizable fashion, the `RELOAD_DIRS` environment variable will be added, which should be a comma-separated string. The string will then be parsed, and the directory names passed to Uvicorn. Directory names are relative to the project root. The string is parsed with `"".split(sep=",")`, and any leading whitespace removed with `"".lstrip()`. This approach is preferred over `"".split(sep=", ")` in case users forget to add a space between the directories.

## Changes

- Upgrade to [Uvicorn 0.13](https://github.com/encode/uvicorn/releases) (7ce6926)
- Implement Uvicorn `reload_dirs` (3b20619)
- Shorten mocker call lines in test_start.py (be3a90f)
- Remove hanging Uvicorn server test (1122080)
- Add pytest-timeout (1085973)
- Add timeouts to web server unit tests (b88fe97)
- Add `reload_dirs` to VSCode debugger config (d811f1a)
- Update VSCode debugger config for new Python key (3882828)
- Document Uvicorn reload settings in README (7a0fbc0)

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
