### PR TITLE
Add inboard logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🚢 inboard 🐳
 
+<img src="https://gist.githubusercontent.com/br3ndonland/d66ce3c8e98cf8bd4f3c24d006409e41/raw/9344741f28c6494c10b0ad142e9b88752e5a6c9a/inboard-logo.svg" alt="inboard logo" width="90%" />
+
 _Docker images to power your Python APIs and help you ship faster._
 
 [![PyPI](https://img.shields.io/pypi/v/inboard?color=success)](https://pypi.org/project/inboard/)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# 🚢 inboard 🐳
+# <div align="center">🚢 inboard 🐳<div>
 
-<img src="https://gist.githubusercontent.com/br3ndonland/d66ce3c8e98cf8bd4f3c24d006409e41/raw/9344741f28c6494c10b0ad142e9b88752e5a6c9a/inboard-logo.svg" alt="inboard logo" width="90%" />
+<div align="center"><img src="https://gist.githubusercontent.com/br3ndonland/d66ce3c8e98cf8bd4f3c24d006409e41/raw/9344741f28c6494c10b0ad142e9b88752e5a6c9a/inboard-logo.svg" alt="inboard logo" width="90%" /></div>
+
+<div align="center">
 
 _Docker images to power your Python APIs and help you ship faster._
+
+</div>
+
+<div align="center">
 
 [![PyPI](https://img.shields.io/pypi/v/inboard?color=success)](https://pypi.org/project/inboard/)
 [![GitHub Container Registry](https://img.shields.io/badge/github%20container%20registry-inboard-success)](https://github.com/users/br3ndonland/packages/container/package/inboard)
@@ -14,7 +20,7 @@ _Docker images to power your Python APIs and help you ship faster._
 [![tests](https://github.com/br3ndonland/inboard/workflows/tests/badge.svg)](https://github.com/br3ndonland/inboard/actions)
 [![codecov](https://codecov.io/gh/br3ndonland/inboard/branch/develop/graph/badge.svg)](https://codecov.io/gh/br3ndonland/inboard)
 
-Brendon Smith ([br3ndonland](https://github.com/br3ndonland/))
+</div>
 
 ## Table of Contents <!-- omit in toc -->
 
@@ -530,3 +536,11 @@ keybase decrypt -i pat-ghcr.asc | docker login ghcr.io -u YOUR_GITHUB_USERNAME -
 
 # can also use keybase pgp encrypt and keybase pgp decrypt, but must export PGP key
 ```
+
+<div align="center">
+
+&mdash; 🚢 <a href="https://github.com/br3ndonland/inboard">inboard</a> 🐳 &mdash;
+
+By Brendon Smith ([br3ndonland](https://github.com/br3ndonland))
+
+</div>


### PR DESCRIPTION
## Description

This PR will add a logo for the project.

<img src="https://user-images.githubusercontent.com/26674818/106368587-bf9c7980-6318-11eb-87d1-4ab6e4163a38.png" alt="inboard logo PNG" width="800px" />

The logo was created with [Figma](https://www.figma.com/), based on the following resources (in the order in which they are seen in the image, top to bottom):

- [GitHub: FastAPI](https://github.com/tiangolo/fastapi)
- [GitHub: Starlette](https://github.com/encode/starlette)
- [GitHub: Uvicorn](https://github.com/encode/uvicorn)
- [Wikimedia: Gunicorn](https://commons.wikimedia.org/wiki/File:Gunicorn_logo_2010.svg)
- [Wikimedia: Python](https://commons.wikimedia.org/wiki/File:Python_logo_and_wordmark.svg)
- [Wikimedia: Docker (container engine)](https://commons.wikimedia.org/wiki/File:Docker_%28container_engine%29_logo.svg)

SVG images can't be uploaded within GitHub comments, so the SVG has been added to a [public GitHub Gist](https://gist.github.com/br3ndonland/d66ce3c8e98cf8bd4f3c24d006409e41).

A Gist is actually a Git repository with some limitations:

- No subdirectories are allowed
- Only code files can be uploaded from the web UI. To upload blobs like PNG files, clone the repo and commit them locally as described below.

To clone a Gist:

```text
git clone git@gist.github.com:GIST_ID.git DIRECTORY_NAME
```

To use images from a Gist:

- Commit the image file to the Gist repo (in the same directory)
- Push the change to GitHub with `git push`
- Click on the "raw" button next to the image
- Copy the URL
- Add the URL to an image tag in the Markdown file.

## Changes

- Add inboard logo to README (5f2a094)
- Center align headings and badges in README (c217e9b)

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
