### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,13 +25,13 @@
 
 - **The default branch is `develop`.**
 - **PRs should be merged into `develop`.** Head branches are deleted automatically after PRs are merged.
-- **The only merges to `master` should be fast-forward merges from `develop`.**
-- **Branch protection is enabled on `develop` and `master`.**
+- **The only merges to `main` should be fast-forward merges from `develop`.**
+- **Branch protection is enabled on `develop` and `main`.**
   - `develop`:
     - Require signed commits
     - Include adminstrators
     - Allow force pushes
-  - `master`:
+  - `main`:
     - Require signed commits
     - Include adminstrators
     - Do not allow force pushes
@@ -39,7 +39,7 @@
 - **To create a release:**
   - Bump the version number in `pyproject.toml` with `poetry version` and commit the changes to `develop`.
   - Push to `develop` and verify all CI checks pass.
-  - Fast-forward merge to `master`, push, and verify all CI checks pass.
+  - Fast-forward merge to `main`, push, and verify all CI checks pass.
   - Create an [annotated and signed Git tag](https://www.git-scm.com/book/en/v2/Git-Basics-Tagging)
     - Follow [SemVer](https://semver.org/) guidelines when choosing a version number.
     - List PRs and commits in the tag message:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3,7 +3,7 @@ name: builds
 on:
   pull_request:
   push:
-    branches: [develop, master]
+    branches: [develop, main]
     tags:
       - "[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
@@ -73,13 +73,13 @@ jobs:
           docker build . --rm --target starlette --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t ghcr.io/br3ndonland/inboard:starlette
           docker build . --rm --target fastapi --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t ghcr.io/br3ndonland/inboard:fastapi
       - name: Push Docker images with latest Python version to registry
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master' && matrix.python-version == '3.9'
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' && matrix.python-version == '3.9'
         run: |
           docker push ghcr.io/br3ndonland/inboard:base
           docker push ghcr.io/br3ndonland/inboard:starlette
           docker push ghcr.io/br3ndonland/inboard:fastapi
       - name: Add Python version tag to Docker images
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
         run: |
           docker tag ghcr.io/br3ndonland/inboard:base ghcr.io/br3ndonland/inboard:base-python${{ matrix.python-version }}
           docker tag ghcr.io/br3ndonland/inboard:starlette ghcr.io/br3ndonland/inboard:starlette-python${{ matrix.python-version }}
@@ -104,7 +104,7 @@ jobs:
           docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"-python${{ matrix.python-version }}
           docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"-python${{ matrix.python-version }}
       - name: Tag and push latest Docker image
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
         run: |
           docker tag ghcr.io/br3ndonland/inboard:fastapi ghcr.io/br3ndonland/inboard:latest
           docker push ghcr.io/br3ndonland/inboard:latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: codeql
 
 on:
   push:
-    branches: [develop, master]
+    branches: [develop, main]
   pull_request:
-    branches: [develop, master]
+    branches: [develop, main]
   schedule:
     - cron: "0 13 * * 1"
   workflow_dispatch:

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -3,7 +3,7 @@ name: hooks
 on:
   pull_request:
   push:
-    branches: [develop, master]
+    branches: [develop, main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   pull_request:
   push:
-    branches: [develop, master]
+    branches: [develop, main]
     paths:
       - "**.lock"
       - "**.py"


### PR DESCRIPTION
## Description

In August 2020, [GitHub announced](https://github.blog/changelog/2020-08-26-set-the-default-branch-for-newly-created-repositories/) that the default branch for new repositories will change from `master` to `main`. To enable branch name changes for existing repositories, they [enabled branch renaming from the web UI](https://github.blog/changelog/2021-01-19-support-for-renaming-an-existing-branch/), and provided some [guidelines for renaming `master` to `main`](https://github.com/github/renaming). Renaming the branch from the web UI doesn't rename references to the branch, such as in GitHub Actions workflows, so this needs to be done with separate commits. Also note, for repos with GitHub Pages sites, the sites may display a `404` after renaming the default branch from `master` to `main` until a commit is pushed to `main`.

## Changes

- Update CONTRIBUTING.md for main branch (7674081)
- Update GitHub Actions workflows for main branch (c03de3d)
- Change branch protection rules from master to main (not shown in Git)

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
