### PR TITLE
Add Docker smoke tests

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -62,6 +62,10 @@ jobs:
         python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python3 -m pip install httpie
       - name: Log in to Docker registry
         run: docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.PAT_GHCR }}
       - name: Build Docker images
@@ -72,6 +76,49 @@ jobs:
             -t ghcr.io/br3ndonland/inboard:base
           docker build . --rm --target starlette --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t ghcr.io/br3ndonland/inboard:starlette
           docker build . --rm --target fastapi --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t ghcr.io/br3ndonland/inboard:fastapi
+      - name: Run Docker containers for testing
+        run: |
+          docker run -d -p 80:80 ghcr.io/br3ndonland/inboard:base
+          docker run -d -p 81:80 ghcr.io/br3ndonland/inboard:starlette
+          docker run -d -p 82:80 ghcr.io/br3ndonland/inboard:fastapi
+      - name: Smoke test Docker containers
+        run: |
+          handle_error_code() {
+            case "$1" in
+            2) : 'Request timed out!' ;;
+            3) : 'Unexpected HTTP 3xx Redirection!' ;;
+            4) : 'HTTP 4xx Client Error!' ;;
+            5) : 'HTTP 5xx Server Error!' ;;
+            6) : 'Exceeded --max-redirects=<n> redirects!' ;;
+            *) : 'Other Error!' ;;
+            esac
+            echo "$_"
+            return "$1"
+          }
+          smoke_test() {
+            if http --check-status --ignore-stdin -q --timeout=5 "$@"; then
+              echo 'Smoke test passed. OK!'
+            else
+              handle_error_code "$?"
+            fi
+          }
+          smoke_test_xfail() {
+            if http --check-status --ignore-stdin -q --timeout=5 "$@" &>/dev/null; then
+              echo 'Smoke test should have failed!'
+              return 1
+            else
+              echo 'Smoke test expected to fail. OK!'
+            fi
+          }
+          smoke_test :80
+          smoke_test :81
+          smoke_test :82
+          smoke_test -a test_username:plunge-germane-tribal-pillar :81/status
+          smoke_test -a test_username:plunge-germane-tribal-pillar :82/status
+          smoke_test_xfail -a test_username:plunge-germane-tribal-incorrect :81/status
+          smoke_test_xfail -a test_username:plunge-germane-tribal-incorrect :82/status
+          smoke_test_xfail :81/status
+          smoke_test_xfail :82/status
       - name: Push Docker images with latest Python version to registry
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' && matrix.python-version == '3.9'
         run: |


### PR DESCRIPTION
## Description

[GitHub Actions](https://docs.github.com/en/actions/guides/building-and-testing-python), [Poetry](https://python-poetry.org/docs/), and [pytest](https://docs.pytest.org/en/latest/) have helped to automate Python testing and Docker builds in this repo. It is simple to test API endpoints _before_ the Docker images are built, using pytest and the [Starlette/FastAPI `TestClient`](https://fastapi.tiangolo.com/tutorial/testing/) as seen in _[test_main.py](https://github.com/br3ndonland/inboard/blob/develop/tests/app/test_main.py)_, but it is also important to test the API endpoints in the Docker images _after_ the images are built. These are commonly called "smoke tests." The inboard repo doesn't yet have automated smoke tests.

After the Docker images are built in GitHub Actions and pushed to GitHub Container Registry (GHCR), I typically pull the images from GHCR and run a few simple HTTPie commands for smoke testing:

```sh
### Pull and run Docker image
docker pull ghcr.io/br3ndonland/inboard
docker run -d -p 80:80 ghcr.io/br3ndonland/inboard

### Smoke test with HTTPie: https://httpie.io/
# GET root endpoint, should be 200
http --check-status -q :80; [[ $? -eq 0 ]]
# GET HTTP Basic auth endpoint without credentials, should be 401 or 403
http --check-status -q :80/status; [[ $? -eq 4 ]]
# GET HTTP Basic auth endpoint with incorrect credentials, should be 401 or 403
http --check-status -q :80/status -a test_username:plunge-germane-tribal-incorrect; [[ $? -eq 4 ]]
# GET HTTP Basic auth endpoint with correct credentials, should be 200
http --check-status -q :80/status -a test_username:plunge-germane-tribal-pillar; [[ $? -eq 0 ]]
```

I would like to automate this, but it is surprisingly awkward to automate smoke tests. I have tried the [Docker SDK for Python](https://docker-py.readthedocs.io/) (aka "[docker-py](https://github.com/docker/docker-py)"), but haven't been happy with the slow speed and frequent errors. Another option is the Postman CLI [Newman](https://github.com/postmanlabs/newman), which can [run Postman collections from the command-line](https://learning.postman.com/docs/running-collections/using-newman-cli/command-line-integration-with-newman/) and [from within a Docker container](https://learning.postman.com/docs/running-collections/using-newman-cli/newman-with-docker/). This is a good approach for large numbers of API requests, but the extra tooling isn't really necessary for only a few smoke tests like this, and at this time they don't have any guidance for GitHub Actions.

As a start, this PR will add some simple smoke tests to the GitHub Actions Docker build workflow, using [HTTPie](https://httpie.io/).

## Changes

- Add Docker smoke tests with HTTPie (13f0d0b)

## Related

- [HTTPie docs: Scripting](https://httpie.io/docs#scripting): More details on the `http` commands above.
- [asm89/smoke.sh](https://github.com/asm89/smoke.sh): Bash smoke testing script.
- [CircleCI | Blog 20200214: Smoke tests in CI/CD pipelines](https://circleci.com/blog/smoke-tests-in-cicd-pipelines/): Helpful example of how to use smoke.sh in CI/CD.
- [Itamar Turner-Trauring | Blog 20190909: Your Docker build needs a smoke test](https://pythonspeed.com/articles/test-your-docker-build/): Some nice tips for smoke testing using the Python standard library. I may consider this approach in the future.
- [Sourcery | Blog 20200204: GitHub Actions for perfect Python continuous integration](https://sourcery.ai/blog/github-actions/): Includes a simple smoke test, starting a Docker container and running one `curl` command.
- [GitHub Actions docs: Service containers](https://docs.github.com/en/actions/guides/about-service-containers): In addition to running Docker containers for testing, GitHub Actions allows entire CI/CD jobs to run within Docker containers of your choosing.
- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
