### PR TITLE
Properly mock logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
     from inboard import logging_conf
 
 
-    LOGGING_CONFIG: Dict[str, Any] = logging_conf.LOGGING_CONFIG
+    LOGGING_CONFIG: dict = logging_conf.LOGGING_CONFIG
     # only show access logs when running Uvicorn with LOG_LEVEL=debug
     LOGGING_CONFIG["loggers"]["gunicorn.access"] = {"propagate": False}
     LOGGING_CONFIG["loggers"]["uvicorn.access"] = {

--- a/inboard/start.py
+++ b/inboard/start.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from logging import Logger
 from pathlib import Path
-from typing import Any, Dict
+from typing import Optional
 
 import uvicorn  # type: ignore
 
@@ -85,7 +85,7 @@ def start_server(
     process_manager: str,
     app_module: str = str(os.getenv("APP_MODULE", "inboard.app.main_base:app")),
     logger: Logger = logging.getLogger(),
-    logging_conf_dict: Dict[str, Any] = None,
+    logging_conf_dict: Optional[dict] = None,
     worker_class: str = str(os.getenv("WORKER_CLASS", "uvicorn.workers.UvicornWorker")),
 ) -> None:
     """Start the Uvicorn or Gunicorn server."""
@@ -113,9 +113,9 @@ def start_server(
                 reload_dirs=reload_dirs,
             )
         else:
-            raise NameError("Process manager needs to be either uvicorn or gunicorn.")
+            raise NameError("Process manager needs to be either uvicorn or gunicorn")
     except Exception as e:
-        logger.error(f"Error when starting server with start script: {e}")
+        logger.error(f"Error when starting server: {e.__class__.__name__} {e}.")
         raise
 
 

--- a/inboard/start.py
+++ b/inboard/start.py
@@ -56,12 +56,12 @@ def set_app_module(logger: Logger = logging.getLogger()) -> str:
     """Set the name of the Python module with the app instance to run."""
     try:
         app_module = str(os.getenv("APP_MODULE"))
-        importlib.util.find_spec(app_module)
+        if not importlib.util.find_spec((module := app_module.split(sep=":")[0])):
+            raise ImportError(f"Unable to find or import {module}")
         logger.debug(f"App module set to {app_module}.")
         return app_module
     except Exception as e:
-        message = f"Error when setting app module: {e}."
-        logger.debug(message)
+        logger.error(f"Error when setting app module: {e.__class__.__name__} {e}.")
         raise
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import List
 
 import pytest
 from fastapi.testclient import TestClient
@@ -81,7 +81,7 @@ def gunicorn_conf_tmp_file_path(
 
 
 @pytest.fixture
-def logging_conf_dict(mocker: MockerFixture) -> Dict[str, Any]:
+def logging_conf_dict(mocker: MockerFixture) -> dict:
     """Load logging configuration dictionary from logging configuration module."""
     return mocker.patch.dict(logging_conf_module.LOGGING_CONFIG)
 
@@ -122,11 +122,16 @@ def logging_conf_tmp_path_no_dict(tmp_path_factory: pytest.TempPathFactory) -> P
     return tmp_dir
 
 
-@pytest.fixture
-def logging_conf_tmp_path_incorrect_extension(tmp_path: Path) -> Path:
+@pytest.fixture(scope="session")
+def logging_conf_tmp_path_incorrect_extension(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
     """Create custom temporary logging config file with incorrect extension."""
-    tmp_file = tmp_path / "tmp_logging_conf.txt"
-    return Path(tmp_file)
+    tmp_dir = tmp_path_factory.mktemp("tmp_log_incorrect_extension")
+    tmp_file = tmp_dir / "tmp_logging_conf"
+    with open(Path(tmp_file), "x") as f:
+        f.write("This file doesn't have the correct extension.\n")
+    return tmp_dir
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import shutil
 from pathlib import Path
@@ -144,19 +143,6 @@ def logging_conf_tmp_path_incorrect_type(
     with open(Path(tmp_file), "x") as f:
         f.write("LOGGING_CONFIG: list = ['Hello', 'World']\n")
     return tmp_dir
-
-
-@pytest.fixture
-def mock_logger(mocker: MockerFixture) -> logging.Logger:
-    """Mock the logger with pytest-mock and a pytest fixture.
-    - https://github.com/pytest-dev/pytest-mock
-    - https://docs.pytest.org/en/latest/fixture.html
-    """
-    logger = logging.getLogger()
-    mocker.patch.object(logger, "debug")
-    mocker.patch.object(logger, "error")
-    mocker.patch.object(logger, "info")
-    return logger
 
 
 @pytest.fixture

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -262,93 +262,98 @@ class TestSetAppModule:
     """
 
     def test_set_app_module_asgi(
-        self, mock_logger: logging.Logger, monkeypatch: pytest.MonkeyPatch
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test `start.set_app_module` using module path to base ASGI app."""
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
         monkeypatch.setenv("APP_MODULE", "inboard.app.main_base:app")
         start.set_app_module(logger=mock_logger)
-        mock_logger.debug.assert_called_once_with(  # type: ignore[attr-defined]
+        mock_logger.debug.assert_called_once_with(
             "App module set to inboard.app.main_base:app."
         )
 
     def test_set_app_module_fastapi(
-        self, mock_logger: logging.Logger, monkeypatch: pytest.MonkeyPatch
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test `start.set_app_module` using module path to FastAPI app."""
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
         monkeypatch.setenv("APP_MODULE", "inboard.app.main_fastapi:app")
         start.set_app_module(logger=mock_logger)
-        mock_logger.debug.assert_called_once_with(  # type: ignore[attr-defined]
+        mock_logger.debug.assert_called_once_with(
             "App module set to inboard.app.main_fastapi:app."
         )
 
     def test_set_app_module_starlette(
-        self, mock_logger: logging.Logger, monkeypatch: pytest.MonkeyPatch
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test `start.set_app_module` using module path to Starlette app."""
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
         monkeypatch.setenv("APP_MODULE", "inboard.app.main_starlette:app")
         start.set_app_module(logger=mock_logger)
-        mock_logger.debug.assert_called_once_with(  # type: ignore[attr-defined]
+        mock_logger.debug.assert_called_once_with(
             "App module set to inboard.app.main_starlette:app."
         )
 
     def test_set_app_module_custom_asgi(
         self,
         app_module_tmp_path: Path,
-        mock_logger: logging.Logger,
+        mocker: MockerFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test `start.set_app_module` with custom module path to base ASGI app."""
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
         monkeypatch.syspath_prepend(app_module_tmp_path)
         monkeypatch.setenv("APP_MODULE", "tmp_app.main_base:app")
         start.set_app_module(logger=mock_logger)
-        mock_logger.debug.assert_called_once_with(  # type: ignore[attr-defined]
+        mock_logger.debug.assert_called_once_with(
             "App module set to tmp_app.main_base:app."
         )
 
     def test_set_app_module_custom_fastapi(
         self,
         app_module_tmp_path: Path,
-        mock_logger: logging.Logger,
+        mocker: MockerFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test `start.set_app_module` with custom module path to FastAPI app."""
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
         monkeypatch.syspath_prepend(app_module_tmp_path)
         monkeypatch.setenv("APP_MODULE", "tmp_app.main_fastapi:app")
         start.set_app_module(logger=mock_logger)
-        mock_logger.debug.assert_called_once_with(  # type: ignore[attr-defined]
+        mock_logger.debug.assert_called_once_with(
             "App module set to tmp_app.main_fastapi:app."
         )
 
     def test_set_app_module_custom_starlette(
         self,
         app_module_tmp_path: Path,
-        mock_logger: logging.Logger,
+        mocker: MockerFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test `start.set_app_module` with custom module path to Starlette app."""
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
         monkeypatch.syspath_prepend(app_module_tmp_path)
         monkeypatch.setenv("APP_MODULE", "tmp_app.main_starlette:app")
         start.set_app_module(logger=mock_logger)
-        mock_logger.debug.assert_called_once_with(  # type: ignore[attr-defined]
+        mock_logger.debug.assert_called_once_with(
             "App module set to tmp_app.main_starlette:app."
         )
 
     def test_set_app_module_incorrect(
         self,
         mocker: MockerFixture,
-        mock_logger: logging.Logger,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test `start.set_app_module` with incorrect module path."""
-        with pytest.raises(ModuleNotFoundError):
-            incorrect_module = "inboard.app.incorrect.main:app"
-            monkeypatch.setenv("APP_MODULE", incorrect_module)
-            logger_error_msg = "Error when setting app module:"
-            incorrect_module_msg = f"No module named {incorrect_module}"
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
+        monkeypatch.setenv("APP_MODULE", "inboard.app.incorrect:app")
+        logger_error_msg = "Error when setting app module"
+        incorrect_module_msg = "Unable to find or import inboard.app.incorrect"
+        with pytest.raises(ImportError):
             start.set_app_module(logger=mock_logger)
-            mock_logger.debug.assert_called_once_with(  # type: ignore[attr-defined]
-                f"{logger_error_msg} {incorrect_module_msg}."
-            )
+        mock_logger.error.assert_called_once_with(
+            f"{logger_error_msg}: ImportError {incorrect_module_msg}."
+        )
 
 
 class TestRunPreStartScript:

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -363,16 +363,16 @@ class TestRunPreStartScript:
 
     def test_run_pre_start_script_py(
         self,
-        mock_logger: logging.Logger,
         mocker: MockerFixture,
         monkeypatch: pytest.MonkeyPatch,
         pre_start_script_tmp_py: Path,
     ) -> None:
         """Test `start.run_pre_start_script` using temporary Python pre-start script."""
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
         monkeypatch.setenv("PRE_START_PATH", str(pre_start_script_tmp_py))
         pre_start_path = os.getenv("PRE_START_PATH")
         start.run_pre_start_script(logger=mock_logger)
-        mock_logger.debug.assert_has_calls(  # type: ignore[attr-defined]
+        mock_logger.debug.assert_has_calls(
             calls=[
                 mocker.call("Checking for pre-start script."),
                 mocker.call(f"Running pre-start script with python {pre_start_path}."),
@@ -382,16 +382,16 @@ class TestRunPreStartScript:
 
     def test_run_pre_start_script_sh(
         self,
-        mock_logger: logging.Logger,
         mocker: MockerFixture,
         monkeypatch: pytest.MonkeyPatch,
         pre_start_script_tmp_sh: Path,
     ) -> None:
         """Test `start.run_pre_start_script` using temporary pre-start shell script."""
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
         monkeypatch.setenv("PRE_START_PATH", str(pre_start_script_tmp_sh))
         pre_start_path = os.getenv("PRE_START_PATH")
         start.run_pre_start_script(logger=mock_logger)
-        mock_logger.debug.assert_has_calls(  # type: ignore[attr-defined]
+        mock_logger.debug.assert_has_calls(
             calls=[
                 mocker.call("Checking for pre-start script."),
                 mocker.call(f"Running pre-start script with sh {pre_start_path}."),
@@ -401,14 +401,14 @@ class TestRunPreStartScript:
 
     def test_run_pre_start_script_no_file(
         self,
-        mock_logger: logging.Logger,
         mocker: MockerFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test `start.run_pre_start_script` with an incorrect file path."""
+        mock_logger = mocker.patch.object(start.logging, "root", autospec=True)
         monkeypatch.setenv("PRE_START_PATH", "/no/file/here")
         start.run_pre_start_script(logger=mock_logger)
-        mock_logger.debug.assert_has_calls(  # type: ignore[attr-defined]
+        mock_logger.debug.assert_has_calls(
             calls=[
                 mocker.call("Checking for pre-start script."),
                 mocker.call("No pre-start script found."),


### PR DESCRIPTION
## Description

The project previously had a [`mock_logger` pytest fixture in _conftest.py_](https://github.com/br3ndonland/inboard/blob/bb088ac/tests/conftest.py#L144) that instantiated a root logger with `logging.getLogger()`. The individual log level attributes were then patched, like `mocker.patch.object(logger, "debug")`. This was problematic, because Mypy thought that the logger didn't have these attributes, requiring frequent `# type: ignore[attr-defined]` comments.

## Changes

The solution is to patch the root logger object [where it is looked up](https://docs.python.org/3/library/unittest.mock.html#where-to-patch), from `inboard.start.logging`. [About 2000 lines into `logging/__init__.py`](https://github.com/python/cpython/blob/b32d8b4/Lib/logging/__init__.py#L1920), there is a module level object `root` that instantiates the root logger. Patching over that object yields the desired result.

Now that the `mock_logger` is a proper `MockerFixture` within each test, pytest and pytest-mock will create the necessary attributes, and the `# type: ignore[attr-defined]` Mypy comments will be removed :recycle: :fire: :art: .

- Properly mock logger in logging config tests
- Properly mock logger in app module tests
- Properly mock logger in pre-start script tests
- Properly mock logger in inboard server tests
- Remove mock logger pytest fixture

## Related

br3ndonland/inboard#3
br3ndonland/inboard#4
br3ndonland/inboard#27

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
