### PR TITLE
Use module path for start script in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /app/
 RUN curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/HEAD/get-poetry.py && \
   python get-poetry.py -y && . $POETRY_HOME/env && poetry install --no-dev --no-interaction --no-root
 COPY inboard /app/inboard
-CMD python /app/inboard/start.py
+ENTRYPOINT ["python"]
+CMD ["-m", "inboard.start"]
 
 FROM base AS fastapi
 ENV APP_MODULE=inboard.app.main_fastapi:app PATH=$POETRY_HOME/bin:$PATH


### PR DESCRIPTION
## Description

The inboard start script was previously run by a [`CMD` with shell notation](https://docs.docker.com/engine/reference/builder/#cmd) in the _Dockerfile_.

```dockerfile
CMD python /app/inboard/start.py
```

This worked, but could have been more flexible.

## Changes

This PR will modify the command used to run the start script in Docker.

```dockerfile
ENTRYPOINT ["python"]
CMD ["-m", "inboard.start"]
```

- Declare the Python executable in an [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint), with the "exec form" (the array syntax, which is preferred).
- Use `CMD` to pass arguments to the Python executable. This allows the arguments to be overridden, so that the file path can still be used instead of the module path if desired.

Use of the module path in this way is dependent on `PYTHONPATH=/app`, which is already set in the _Dockerfile_.

To try it out locally:

```sh
cd /path/to/inboard
docker build . --rm --target fastapi -t localhost/br3ndonland/inboard:fastapi
# run start.py with the module path
docker run -d -p 80:80 localhost/br3ndonland/inboard:fastapi
# override the module path with a file path instead
docker stop $(docker ps -aq)
docker run -d -p 80:80 localhost/br3ndonland/inboard:fastapi /app/inboard/start.py
```

## Related

br3ndonland/inboard#2
br3ndonland/inboard#27

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
