### PR TITLE
Refactor start script to improve organization of Gunicorn and Uvicorn server settings

### DIFF
--- a/inboard/start.py
+++ b/inboard/start.py
@@ -4,27 +4,14 @@ import logging
 import logging.config
 import os
 import subprocess
-from logging import Logger
 from pathlib import Path
 from typing import Optional
 
 import uvicorn  # type: ignore
 
 
-def set_conf_path(module_stem: str) -> str:
-    """Set the path to a configuration file."""
-    conf_var = str(
-        os.getenv(f"{module_stem.upper()}_CONF", f"/app/inboard/{module_stem}_conf.py")
-    )
-    if conf_var and Path(conf_var).is_file():
-        conf_path = conf_var
-    else:
-        raise FileNotFoundError(f"Unable to find {conf_var}")
-    return conf_path
-
-
 def configure_logging(
-    logger: Logger = logging.getLogger(),
+    logger: logging.Logger = logging.getLogger(),
     logging_conf: str = os.getenv("LOGGING_CONF", "inboard.logging_conf"),
 ) -> dict:
     """Configure Python logging based on a path to a logging module or file."""
@@ -52,20 +39,7 @@ def configure_logging(
         raise
 
 
-def set_app_module(logger: Logger = logging.getLogger()) -> str:
-    """Set the name of the Python module with the app instance to run."""
-    try:
-        app_module = str(os.getenv("APP_MODULE"))
-        if not importlib.util.find_spec((module := app_module.split(sep=":")[0])):
-            raise ImportError(f"Unable to find or import {module}")
-        logger.debug(f"App module set to {app_module}.")
-        return app_module
-    except Exception as e:
-        logger.error(f"Error when setting app module: {e.__class__.__name__} {e}.")
-        raise
-
-
-def run_pre_start_script(logger: Logger = logging.getLogger()) -> str:
+def run_pre_start_script(logger: logging.Logger = logging.getLogger()) -> str:
     """Run a pre-start script at the provided path."""
     logger.debug("Checking for pre-start script.")
     pre_start_path = os.getenv("PRE_START_PATH", "/app/inboard/app/prestart.py")
@@ -81,42 +55,67 @@ def run_pre_start_script(logger: Logger = logging.getLogger()) -> str:
     return message
 
 
+def set_app_module(logger: logging.Logger = logging.getLogger()) -> str:
+    """Set the name of the Python module with the app instance to run."""
+    try:
+        app_module = str(os.getenv("APP_MODULE"))
+        if not importlib.util.find_spec((module := app_module.split(sep=":")[0])):
+            raise ImportError(f"Unable to find or import {module}")
+        logger.debug(f"App module set to {app_module}.")
+        return app_module
+    except Exception as e:
+        logger.error(f"Error when setting app module: {e.__class__.__name__} {e}.")
+        raise
+
+
+def set_gunicorn_options() -> list:
+    """Set options for running the Gunicorn server."""
+    gunicorn_conf_path = os.getenv("GUNICORN_CONF", "/app/inboard/gunicorn_conf.py")
+    worker_class = os.getenv("WORKER_CLASS", "uvicorn.workers.UvicornWorker")
+    if not Path(gunicorn_conf_path).is_file():
+        raise FileNotFoundError(f"Unable to find {gunicorn_conf_path}")
+    return ["gunicorn", "-k", worker_class, "-c", gunicorn_conf_path]
+
+
+def set_uvicorn_options(log_config: Optional[dict] = None) -> dict:
+    """Set options for running the Uvicorn server."""
+    with_reload = (
+        True
+        if (value := os.getenv("WITH_RELOAD")) and value.lower() == "true"
+        else False
+    )
+    reload_dirs = (
+        [d.lstrip() for d in str(os.getenv("RELOAD_DIRS")).split(sep=",")]
+        if os.getenv("RELOAD_DIRS")
+        else None
+    )
+    return dict(
+        host=os.getenv("HOST", "0.0.0.0"),
+        port=int(os.getenv("PORT", "80")),
+        log_config=log_config,
+        log_level=os.getenv("LOG_LEVEL", "info"),
+        reload=with_reload,
+        reload_dirs=reload_dirs,
+    )
+
+
 def start_server(
     process_manager: str,
-    app_module: str = str(os.getenv("APP_MODULE", "inboard.app.main_base:app")),
-    logger: Logger = logging.getLogger(),
+    app_module: str,
+    logger: logging.Logger = logging.getLogger(),
     logging_conf_dict: Optional[dict] = None,
-    worker_class: str = str(os.getenv("WORKER_CLASS", "uvicorn.workers.UvicornWorker")),
 ) -> None:
     """Start the Uvicorn or Gunicorn server."""
     try:
         if process_manager == "gunicorn":
             logger.debug("Running Uvicorn with Gunicorn.")
-            gunicorn_conf_path = set_conf_path("gunicorn")
-            subprocess.run(
-                ["gunicorn", "-k", worker_class, "-c", gunicorn_conf_path, app_module]
-            )
+            gunicorn_options: list = set_gunicorn_options()
+            gunicorn_options.append(app_module)
+            subprocess.run(gunicorn_options)
         elif process_manager == "uvicorn":
-            with_reload = (
-                True
-                if (value := os.getenv("WITH_RELOAD")) and value.lower() == "true"
-                else False
-            )
-            reload_dirs = (
-                [d.lstrip() for d in str(os.getenv("RELOAD_DIRS")).split(sep=",")]
-                if os.getenv("RELOAD_DIRS")
-                else None
-            )
             logger.debug("Running Uvicorn without Gunicorn.")
-            uvicorn.run(
-                app_module,
-                host=os.getenv("HOST", "0.0.0.0"),
-                port=int(os.getenv("PORT", "80")),
-                log_config=logging_conf_dict,
-                log_level=os.getenv("LOG_LEVEL", "info"),
-                reload=with_reload,
-                reload_dirs=reload_dirs,
-            )
+            uvicorn_options: dict = set_uvicorn_options(log_config=logging_conf_dict)
+            uvicorn.run(app_module, **uvicorn_options)
         else:
             raise NameError("Process manager needs to be either uvicorn or gunicorn")
     except Exception as e:


### PR DESCRIPTION
## Description

The core logic for running the Uvicorn and Gunicorn+Uvicorn servers is located in _[start.py](https://github.com/br3ndonland/inboard/blob/develop/inboard/start.py)_. The `start.start_server()` method is what actually starts the servers. Gunicorn and Uvicorn are configured differently, so the `start.start_server()` method ended up getting quite complex in order to handle these differences.

This PR will refactor the configuration options passed to Gunicorn and Uvicorn into separate functions. The result is a start script with the same programming API and almost exactly the same line length, but improved readability and separation of concerns.

## Changes

- Refactor Gunicorn and Uvicorn options into separate functions, `start.set_gunicorn_options()` and `start.set_uvicorn_options()`.
- Remove `start.set_conf_path()`: this function was written in a general way to find either Gunicorn or logging configuration files. Starting with ff9155a, it became used only for Gunicorn configuration files. Now that the configuration options for Gunicorn are in a separate function, the logic from `set_conf_path()` can be moved there.
- Simplify logger type annotations: simply `import logging` and annotate logger objects passed in as function arguments with `logging.Logger` instead of having a separate import for `from logging import Logger`.
- Reorganize _test_start.py_ to more clearly reflect order of _start.py_

## Related

br3ndonland/inboard#2
br3ndonland/inboard#3
br3ndonland/inboard@ff9155a

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
