### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -67,12 +67,13 @@ jobs:
       - name: Run unit tests
         run: poetry run pytest --cov-report=xml
       - name: Upload test coverage report to Codecov
+        if: matrix.python-version == '3.10'
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
           flags: unit
       - name: Build Python package with latest Python version and publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == 3.9
+        if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.10'
         run: |
           PACKAGE_VERSION=$(poetry version -s)
           GIT_TAG_VERSION=$(echo ${{ github.ref }} | cut -d / -f 3)
@@ -91,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         linux-version: ["", "alpine", "slim"]
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -231,7 +232,7 @@ jobs:
             -u ${{ github.actor }} --password-stdin
       - name: Tag and push Docker images with latest tags
         if: >
-          matrix.python-version == 3.9 &&
+          matrix.python-version == '3.10' &&
           (
             startsWith(github.ref, 'refs/tags/') ||
             github.ref == 'refs/heads/develop' ||

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.10"
       - name: Set up Poetry cache for Python dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -62,6 +62,7 @@ jobs:
       - name: Run unit tests
         run: poetry run pytest --cov-report=xml
       - name: Upload test coverage report to Codecov
+        if: matrix.python-version == '3.10'
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.9 LINUX_VERSION=
+ARG PYTHON_VERSION=3.10 LINUX_VERSION=
 FROM python:${PYTHON_VERSION}${LINUX_VERSION:+-$LINUX_VERSION} AS base
 LABEL org.opencontainers.image.authors="Brendon Smith <bws@bws.bio>"
 LABEL org.opencontainers.image.description="Docker images and utilities to power your Python APIs and help you ship faster."

--- a/inboard/app/main_base.py
+++ b/inboard/app/main_base.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os
 import sys
-from typing import Awaitable, Callable, Dict
+from typing import Awaitable, Callable
 
 
 class App:
@@ -9,13 +11,13 @@ class App:
     https://www.uvicorn.org/
     """
 
-    def __init__(self, scope: Dict) -> None:
+    def __init__(self, scope: dict) -> None:
         assert scope["type"] == "http"
         self.scope = scope
 
     async def __call__(
-        self, receive: Dict, send: Callable[[Dict], Awaitable]
-    ) -> Dict[str, str]:
+        self, receive: dict, send: Callable[[dict], Awaitable]
+    ) -> dict[str, str]:
         await send(
             {
                 "type": "http.response.start",
@@ -32,7 +34,7 @@ class App:
             raise NameError("Process manager needs to be either uvicorn or gunicorn.")
         server = "Uvicorn" if process_manager == "uvicorn" else "Uvicorn, Gunicorn,"
         message = f"Hello World, from {server} and Python {version}!"
-        response: Dict = {"type": "http.response.body", "body": message.encode("utf-8")}
+        response: dict = {"type": "http.response.body", "body": message.encode("utf-8")}
         await send(response)
         return response
 

--- a/inboard/app/utilities_starlette.py
+++ b/inboard/app/utilities_starlette.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import base64
 import os
 import secrets
-from typing import Optional, Tuple
 
 from starlette.authentication import (
     AuthCredentials,
@@ -17,7 +18,7 @@ class BasicAuth(AuthenticationBackend):
 
     async def authenticate(
         self, request: HTTPConnection
-    ) -> Optional[Tuple[AuthCredentials, SimpleUser]]:
+    ) -> tuple[AuthCredentials, SimpleUser] | None:
         """Authenticate a Starlette request with HTTP Basic auth."""
         if "Authorization" not in request.headers:
             return None

--- a/inboard/gunicorn_conf.py
+++ b/inboard/gunicorn_conf.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 import multiprocessing
 import os
-from typing import Optional
 
 from inboard.logging_conf import configure_logging
 
 
 def calculate_workers(
-    max_workers: Optional[str] = None,
-    total_workers: Optional[str] = None,
+    max_workers: str | None = None,
+    total_workers: str | None = None,
     workers_per_core: str = "1",
 ) -> int:
     """Calculate the number of Gunicorn worker processes."""

--- a/inboard/logging_conf.py
+++ b/inboard/logging_conf.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import importlib.util
 import logging
 import logging.config
 import os
 import sys
 from pathlib import Path
-from typing import Optional, Set
 
 
 def find_and_load_logging_conf(logging_conf: str) -> dict:
@@ -30,7 +31,7 @@ def find_and_load_logging_conf(logging_conf: str) -> dict:
 
 def configure_logging(
     logger: logging.Logger = logging.getLogger(),
-    logging_conf: Optional[str] = os.getenv("LOGGING_CONF"),
+    logging_conf: str | None = os.getenv("LOGGING_CONF"),
 ) -> dict:
     """Configure Python logging given the name of a logging module or file."""
     try:
@@ -67,7 +68,7 @@ class LogFilter(logging.Filter):
     def __init__(
         self,
         name: str = "",
-        filters: Optional[Set[str]] = None,
+        filters: set[str] | None = None,
     ) -> None:
         """Initialize a filter."""
         self.name = name
@@ -85,7 +86,7 @@ class LogFilter(logging.Filter):
         return all(match not in message for match in self.filters)
 
     @staticmethod
-    def set_filters(input_filters: Optional[str] = None) -> Optional[Set[str]]:
+    def set_filters(input_filters: str | None = None) -> set[str] | None:
         """Set log message filters.
 
         Filters identify log messages to filter out, so that the logger does not

--- a/inboard/start.py
+++ b/inboard/start.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import importlib.util
 import json
 import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import Optional
 
 import uvicorn  # type: ignore
 
@@ -52,7 +53,7 @@ def set_gunicorn_options(app_module: str) -> list:
     return ["gunicorn", "-k", worker_class, "-c", gunicorn_conf_path, app_module]
 
 
-def _split_uvicorn_option(option: str) -> Optional[list]:
+def _split_uvicorn_option(option: str) -> list | None:
     return (
         [option_item.strip() for option_item in str(option_value).split(sep=",")]
         if (option_value := os.getenv(option.upper()))
@@ -77,7 +78,7 @@ def _update_uvicorn_config_options(uvicorn_config_options: dict) -> dict:
     return uvicorn_config_options
 
 
-def set_uvicorn_options(log_config: Optional[dict] = None) -> dict:
+def set_uvicorn_options(log_config: dict | None = None) -> dict:
     """Set options for running the Uvicorn server."""
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "80"))
@@ -99,7 +100,7 @@ def start_server(
     process_manager: str,
     app_module: str,
     logger: logging.Logger = logging.getLogger(),
-    logging_conf_dict: Optional[dict] = None,
+    logging_conf_dict: dict | None = None,
 ) -> None:
     """Start the Uvicorn or Gunicorn server."""
     try:

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import sys
-from typing import Dict, List
 
 import pytest
 from fastapi import FastAPI
@@ -14,7 +15,7 @@ class TestCors:
     [Starlette CORS docs](https://www.starlette.io/middleware/#corsmiddleware).
     """
 
-    origins: Dict[str, List[str]] = {
+    origins: dict[str, list[str]] = {
         "allowed": [
             "http://br3ndon.land",
             "https://br3ndon.land",
@@ -38,7 +39,7 @@ class TestCors:
         self, allowed_origin: str, client: TestClient
     ) -> None:
         """Test pre-flight response to cross-origin request from allowed origin."""
-        headers: Dict[str, str] = {
+        headers: dict[str, str] = {
             "Origin": allowed_origin,
             "Access-Control-Request-Method": "GET",
             "Access-Control-Request-Headers": "X-Example",
@@ -54,7 +55,7 @@ class TestCors:
         self, disallowed_origin: str, client: TestClient
     ) -> None:
         """Test pre-flight response to cross-origin request from disallowed origin."""
-        headers: Dict[str, str] = {
+        headers: dict[str, str] = {
             "Origin": disallowed_origin,
             "Access-Control-Request-Method": "GET",
             "Access-Control-Request-Headers": "X-Example",

--- a/tests/test_gunicorn_conf.py
+++ b/tests/test_gunicorn_conf.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import multiprocessing
 import subprocess
 from pathlib import Path
-from typing import Optional
 
 import pytest
 
@@ -20,7 +21,7 @@ class TestCalculateWorkers:
         assert gunicorn_conf.workers == max(cores, 2)
 
     @pytest.mark.parametrize("max_workers", (None, "1", "2", "5", "10"))
-    def test_calculate_workers_max(self, max_workers: Optional[str]) -> None:
+    def test_calculate_workers_max(self, max_workers: str | None) -> None:
         """Test Gunicorn worker process calculation with custom maximum."""
         cores = multiprocessing.cpu_count()
         default = max(cores, 2)
@@ -31,7 +32,7 @@ class TestCalculateWorkers:
             assert result == default
 
     @pytest.mark.parametrize("total_workers", (None, "1", "2", "5", "10"))
-    def test_calculate_workers_total(self, total_workers: Optional[str]) -> None:
+    def test_calculate_workers_total(self, total_workers: str | None) -> None:
         """Test Gunicorn worker process calculation with custom total."""
         cores = multiprocessing.cpu_count()
         result = gunicorn_conf.calculate_workers(None, total_workers)


### PR DESCRIPTION
## Description

This PR will add [Python 3.10](https://docs.python.org/3/whatsnew/3.10.html) support to inboard.

## Changes

### GitHub Actions

- [x] **Add Python 3.10 to GitHub Actions workflows**
- [x] **Update to stable Python 3.10 when it is released**
  - [What's new in Python 3.10](https://docs.python.org/3/whatsnew/3.10.html)
  - [actions/python-versions 3.10.0](https://github.com/actions/python-versions/releases/tag/3.10.0-117470)
  - actions/setup-python#249
- [x] **Update Python version syntax to enclose version numbers in quotes**
  - Python versions must now be quoted in YAML. `3.10` (without quotes) is interpreted as a float and becomes `3.1`, so `"3.10"` must be used instead.
  - https://github.com/actions/setup-python/issues/249#issuecomment-934299359
  - https://dev.to/hugovk/the-python-3-1-problem-85g

### Poetry

- [x] **Install Poetry successfully with Python 3.10**: Poetry has introduced some breaking changes recently. To help buffer against these breaking changes, and to promote reproducible Poetry installations, #47 updated Poetry installations to use [`pipx`](https://pypa.github.io/pipx/) instead of _[get-poetry.py](https://github.com/python-poetry/poetry/blob/1.1.11/get-poetry.py)_ or its replacement _install-poetry.py_. This change eliminated all of the issues seen with _get-poetry.py_ and _install-poetry.py_.
- [x] **Install Poetry dependencies successfully with Python 3.10**: Installing Poetry with `pipx` (#47) eliminated the issues seen when installing dependencies with Python 3.10.
- [x] **Ensure Python 3.10 classifier is included with Poetry package builds**: Fixed as of Poetry 1.1.11 (python-poetry/poetry#4581).

<details><summary>Expand this details element for details on some of the problems seen with <em>get-poetry.py</em> and <em>install-poetry.py</em> on Python 3.10.</summary>

The previous _get-poetry.py_ install script is not compatible with Python 3.10. Attempts to install Poetry with Python 3.10 and _get-poetry.py_ may raise `ModuleNotFoundError` (python-poetry/poetry#3071, python-poetry/poetry#3345) and other errors:

```text
 Traceback (most recent call last):
  File "/opt/poetry/bin/poetry", line 17, in <module>
    from poetry.console import main
  File "/opt/poetry/lib/poetry/console/__init__.py", line 1, in <module>
    from .application import Application
  File "/opt/poetry/lib/poetry/console/application.py", line 3, in <module>
    from cleo import Application as BaseApplication
ModuleNotFoundError: No module named 'cleo'
```

[Poetry 1.1.11](https://github.com/python-poetry/poetry/releases/tag/1.1.11) claimed to resolve Python 3.10 issues, but it did not.

The new _install-poetry.py_ script (added in python-poetry/poetry#3706) must therefore be used, but it was problematic when it was introduced.

**_install-poetry.py_ did not respect `POETRY_VIRTUALENVS_CREATE`**

As of Poetry 1.1.7, there may be complications when using _install-poetry.py_ without a virtualenv (`POETRY_VIRTUALENVS_CREATE=false`). When installing dependencies, the following error is frequently seen:

```text
OSError

Could not find a suitable TLS CA certificate bundle, invalid path:
/opt/poetry/venv/lib/python3.9/site-packages/certifi/cacert.pem

at /opt/poetry/venv/lib/python3.9/site-packages/requests/adapters.py:227
in cert_verify
```

In some situations, Poetry uninstalls its own dependencies. The `OSError` above occurs because Poetry uninstalls `requests` and `certifi`, then complains that it can't find them. See:

- python-poetry/poetry#3139
- python-poetry/poetry#3957
- python-poetry/poetry#4195
- python-poetry/poetry#4336
- python-poetry/poetry#4470

Poetry may have also been incorrectly attempting to read from its virtualenv (instead of [`site-packages`](https://docs.python.org/3/library/site.html)) if it was not respecting `POETRY_VIRTUALENVS_CREATE`. Downstream steps also did not appear to respect `POETRY_VIRTUALENVS_CREATE`, so the application did not run. See:

- python-poetry/poetry#3870
- https://github.com/python-poetry/poetry/discussions/4271
- python-poetry/poetry#4369
- python-poetry/poetry#4414
- https://github.com/python-poetry/poetry/issues/4429#issuecomment-903694778
- python-poetry/poetry#4430
- python-poetry/poetry#4433

**Poetry did not install packages correctly with _install-poetry.py_, `POETRY_VIRTUALENVS_CREATE`, and Python 3.10**

Poetry errored out with a `JSONDecodeError` when attempting to install packages with Python 3.10. See python-poetry/poetry#4210. This appeared to be resolved as of Poetry 1.2.0a2.

There were also errors with Poetry's own virtualenv when using _install-poetry.py_, `POETRY_VIRTUALENVS_CREATE`, and multiple versions of Python, including 3.8 and 3.9. Error tracebacks typically reported a traceback sequence of `CalledProcessError` -> `EnvCommandError` -> `PoetryException` for each package, and appeared to involve `virtualenv` and `pip`. These errors may have been related to Poetry's "new installer", which can be disabled with the command `poetry config experimental.new-installer false` or the environment variable `POETRY_EXPERIMENTAL_NEW_INSTALLER=false`.

Example traceback from a GitHub Actions run:

```text
  CalledProcessError

  Command '['/opt/poetry/venv/bin/python', '/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip', 'install', '--disable-pip-version-check', '--prefix', '/opt/hostedtoolcache/Python/3.8.11/x64', '--no-deps', 'file:/home/runner/.cache/pypoetry/artifacts/94/aa/c7/f2115774653c0d0bf72ce93092eb73de70854164adf9f00749a952ba9c/websockets-9.1-cp38-cp38-manylinux2010_x86_64.whl']' returned non-zero exit status 1.

  at /opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/subprocess.py:516 in run
       512│             # We don't call process.wait() as .__exit__ does that for us.
       513│             raise
       514│         retcode = process.poll()
       515│         if check and retcode:
    →  516│             raise CalledProcessError(retcode, process.args,
       517│                                      output=stdout, stderr=stderr)
       518│     return CompletedProcess(process.args, retcode, stdout, stderr)
       519│
       520│

The following error occurred when trying to handle this error:


  EnvCommandError

  Command ['/opt/poetry/venv/bin/python', '/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip', 'install', '--disable-pip-version-check', '--prefix', '/opt/hostedtoolcache/Python/3.8.11/x64', '--no-deps', 'file:/home/runner/.cache/pypoetry/artifacts/94/aa/c7/f2115774653c0d0bf72ce93092eb73de70854164adf9f00749a952ba9c/websockets-9.1-cp38-cp38-manylinux2010_x86_64.whl'] errored with the following return code 1, and output:
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/runpy.py", line 194, in _run_module_as_main
      return _run_code(code, main_globals, None,
    File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/runpy.py", line 87, in _run_code
      exec(code, run_globals)
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/__main__.py", line 24, in <module>
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_internal/cli/main.py", line 71, in main
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_internal/commands/__init__.py", line 96, in create_command
    File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/importlib/__init__.py", line 127, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 618, in _load_backward_compatible
    File "<frozen zipimport>", line 259, in load_module
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_internal/commands/install.py", line 15, in <module>
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 618, in _load_backward_compatible
    File "<frozen zipimport>", line 259, in load_module
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_internal/cli/req_command.py", line 21, in <module>
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 618, in _load_backward_compatible
    File "<frozen zipimport>", line 259, in load_module
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_internal/req/__init__.py", line 8, in <module>
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 618, in _load_backward_compatible
    File "<frozen zipimport>", line 259, in load_module
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_internal/req/req_install.py", line 32, in <module>
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 618, in _load_backward_compatible
    File "<frozen zipimport>", line 259, in load_module
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_internal/pyproject.py", line 4, in <module>
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 618, in _load_backward_compatible
    File "<frozen zipimport>", line 259, in load_module
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_vendor/toml/__init__.py", line 6, in <module>
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 618, in _load_backward_compatible
    File "<frozen zipimport>", line 259, in load_module
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_vendor/toml/encoder.py", line 6, in <module>
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
    File "<frozen importlib._bootstrap>", line 618, in _load_backward_compatible
    File "<frozen zipimport>", line 259, in load_module
    File "/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl/pip/_vendor/toml/decoder.py", line 7, in <module>
    File "<frozen importlib._bootstrap>", line 991, in _find_and_load
    File "<frozen importlib._bootstrap>", line 971, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 914, in _find_spec
    File "<frozen importlib._bootstrap_external>", line 1407, in find_spec
    File "<frozen importlib._bootstrap_external>", line 1381, in _get_spec
    File "<frozen importlib._bootstrap_external>", line 1362, in _legacy_get_spec
    File "<frozen importlib._bootstrap>", line 414, in spec_from_loader
    File "<frozen importlib._bootstrap_external>", line 709, in spec_from_file_location
    File "<frozen zipimport>", line 191, in get_filename
    File "<frozen zipimport>", line 709, in _get_module_code
    File "<frozen zipimport>", line 536, in _get_data
  FileNotFoundError: [Errno 2] No such file or directory: '/opt/poetry/venv/lib/python3.8/site-packages/virtualenv/seed/wheels/embed/pip-21.0.1-py3-none-any.whl'


  at /opt/poetry/venv/lib/python3.8/site-packages/poetry/utils/env.py:1300 in _run
      1296│                 output = subprocess.check_output(
      1297│                     cmd, stderr=subprocess.STDOUT, env=env, **kwargs
      1298│                 )
      1299│         except CalledProcessError as e:
    → 1300│             raise EnvCommandError(e, input=input_)
      1301│
      1302│         return decode(output)
      1303│
      1304│     def execute(self, bin: str, *args: str, **kwargs: Any) -> Optional[int]:

The following error occurred when trying to handle this error:


  PoetryException

  Failed to install file:/home/runner/.cache/pypoetry/artifacts/94/aa/c7/f2115774653c0d0bf72ce93092eb73de70854164adf9f00749a952ba9c/websockets-9.1-cp38-cp38-manylinux2010_x86_64.whl

  at /opt/poetry/venv/lib/python3.8/site-packages/poetry/utils/pip.py:60 in pip_install
       56│                     *env.get_pip_command(),
       57│                     *args,
       58│                     env={**os.environ, "PYTHONPATH": str(env.purelib)},
       59│                 )
    →  60│         raise PoetryException(f"Failed to install {path.as_posix()}") from e
       61│
       62│
       63│ def pip_editable_install(directory: Path, environment: Env) -> Union[int, str]:
       64│     return pip_install(

```

May be somewhat related to:

- python-poetry/poetry#3336
- python-poetry/poetry#3843
- python-poetry/poetry#4195
- python-poetry/poetry#4463

**_install-poetry.py_ was not present in stable releases**

Poetry 1.1 releases did not include _install-poetry.py_ in their source tree. This could be a problem for projects that fetch _install-poetry.py_ from a specific Git tag, as this project does (br3ndonland/inboard#44).

For example:

- https://raw.githubusercontent.com/python-poetry/poetry/1.1.11/get-poetry.py returns the _get-poetry.py_ install script
- https://raw.githubusercontent.com/python-poetry/poetry/1.1.11/install-poetry.py returns `404`

</details>

### _pydantic_ and typing

- [x] **Ensure _pydantic_ provides Python package wheels for Python 3.10**: Python 3.10 support was added in [_pydantic_ 1.9.0](https://github.com/samuelcolvin/pydantic/releases/tag/v1.9.0).
- [x] **Ensure _pydantic_ models are compatible with Python 3.10 type annotations**:
  - The Python 3.10 union operator (the pipe, like `str | None`) will not be used on _pydantic_ models. This project still supports Python 3.8 and 3.9. If running Python 3.9 or below, _pydantic_ is not compatible with the union operator, even if annotations are imported with `from __future__ import annotations`.
  - [PEP 604: Allow writing union types as `X | Y`](https://peps.python.org/pep-0604/)
  - https://github.com/samuelcolvin/pydantic/issues/2597#issuecomment-1086194186
  - https://github.com/samuelcolvin/pydantic/pull/2609#issuecomment-1084341812
  - https://github.com/samuelcolvin/pydantic/issues/3300#issuecomment-1034007897
- [x] **Update type annotations for Python 3.10** (all except the union types on _pydantic_ model fields)

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).

### GitHub Actions

- actions/setup-python#249

### Poetry

- br3ndonland/inboard#44
- br3ndonland/inboard#47
- python-poetry/poetry#3071
- python-poetry/poetry#3139
- python-poetry/poetry#3336
- python-poetry/poetry#3345
- python-poetry/poetry#3706
- python-poetry/poetry#3870
- python-poetry/poetry#3957
- python-poetry/poetry#4056
- python-poetry/poetry#4195
- python-poetry/poetry#4210
- https://github.com/python-poetry/poetry/discussions/4271
- python-poetry/poetry#4336
- python-poetry/poetry#4369
- python-poetry/poetry#4414
- python-poetry/poetry#4429
- python-poetry/poetry#4430
- python-poetry/poetry#4433
- python-poetry/poetry#4463
- python-poetry/poetry#4470
- python-poetry/poetry#4581

### _pydantic_ and typing

- samuelcolvin/pydantic#2597
- samuelcolvin/pydantic#2609
- samuelcolvin/pydantic#3300
- [_pydantic_ 1.9.0](https://github.com/samuelcolvin/pydantic/releases/tag/v1.9.0)
- [PEP 604: Allow writing union types as `X | Y`](https://peps.python.org/pep-0604/)
- [Python 3 docs: What's new in Python 3.10](https://docs.python.org/3/whatsnew/3.10.html)
