### PR TITLE
Add support for Alpine Linux

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -60,6 +60,7 @@ jobs:
     needs: [python]
     strategy:
       matrix:
+        alpine-version: ["", "alpine"]
         python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
@@ -67,37 +68,50 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: python3 -m pip install httpie
+      - name: Set up versions and Docker tags for Python and Alpine Linux
+        id: setup
+        run: |
+          ALPINE_VERSION=${{ matrix.alpine-version }}
+          ALPINE_TAG=${ALPINE_VERSION:+-$ALPINE_VERSION}
+          PYTHON_VERSION=${{ matrix.python-version }}
+          PYTHON_TAG="-python$PYTHON_VERSION"
+          echo "ALPINE_VERSION=$ALPINE_VERSION" >> $GITHUB_ENV
+          echo "ALPINE_TAG=$ALPINE_TAG" >> $GITHUB_ENV
+          echo "PYTHON_VERSION=$PYTHON_VERSION" >> $GITHUB_ENV
+          echo "PYTHON_TAG=$PYTHON_TAG" >> $GITHUB_ENV
       - name: Log in to Docker registry
         run: |
           echo ${{ secrets.PAT_GHCR }} | docker login ghcr.io \
             -u ${{ github.actor }} --password-stdin
       - name: Build Docker images
         run: |
-          PY=${{ matrix.python-version }}
           docker build . --rm --target base \
-            --build-arg PYTHON_VERSION="$PY" \
-            --cache-from python:"$PY" \
-            -t ghcr.io/br3ndonland/inboard:base
+            --build-arg ALPINE_VERSION="$ALPINE_VERSION" \
+            --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
+            --cache-from python:"$PYTHON_VERSION$ALPINE_TAG" \
+            -t ghcr.io/br3ndonland/inboard:base"$ALPINE_TAG"
           docker build . --rm --target starlette \
-            --build-arg PYTHON_VERSION="$PY" \
-            -t ghcr.io/br3ndonland/inboard:starlette
+            --build-arg ALPINE_VERSION="$ALPINE_VERSION" \
+            --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
+            -t ghcr.io/br3ndonland/inboard:starlette"$ALPINE_TAG"
           docker build . --rm --target fastapi \
-            --build-arg PYTHON_VERSION="$PY" \
-            -t ghcr.io/br3ndonland/inboard:fastapi
+            --build-arg ALPINE_VERSION="$ALPINE_VERSION" \
+            --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
+            -t ghcr.io/br3ndonland/inboard:fastapi"$ALPINE_TAG"
       - name: Run Docker containers for testing
         run: |
           docker run -d -p 80:80 \
             -e "BASIC_AUTH_USERNAME=test_user" \
             -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
-            ghcr.io/br3ndonland/inboard:base
+            ghcr.io/br3ndonland/inboard:base"$ALPINE_TAG"
           docker run -d -p 81:80 \
             -e "BASIC_AUTH_USERNAME=test_user" \
             -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
-            ghcr.io/br3ndonland/inboard:starlette
+            ghcr.io/br3ndonland/inboard:starlette"$ALPINE_TAG"
           docker run -d -p 82:80 \
             -e "BASIC_AUTH_USERNAME=test_user" \
             -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
-            ghcr.io/br3ndonland/inboard:fastapi
+            ghcr.io/br3ndonland/inboard:fastapi"$ALPINE_TAG"
       - name: Smoke test Docker containers
         run: |
           handle_error_code() {
@@ -145,55 +159,53 @@ jobs:
             github.ref == 'refs/heads/main'
           )
         run: |
-          docker push ghcr.io/br3ndonland/inboard:base
-          docker push ghcr.io/br3ndonland/inboard:starlette
-          docker push ghcr.io/br3ndonland/inboard:fastapi
+          docker push ghcr.io/br3ndonland/inboard:base"$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:starlette"$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:fastapi"$ALPINE_TAG"
           docker tag \
-            ghcr.io/br3ndonland/inboard:fastapi \
-            ghcr.io/br3ndonland/inboard:latest
-          docker push ghcr.io/br3ndonland/inboard:latest
+            ghcr.io/br3ndonland/inboard:fastapi"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:latest"$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:latest"$ALPINE_TAG"
       - name: Tag and push Docker images with Python version
         if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         run: |
-          PY_TAG=python${{ matrix.python-version }}
           docker tag \
-            ghcr.io/br3ndonland/inboard:base \
-            ghcr.io/br3ndonland/inboard:base-"$PY_TAG"
+            ghcr.io/br3ndonland/inboard:base"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:base"$PYTHON_TAG$ALPINE_TAG"
           docker tag \
-            ghcr.io/br3ndonland/inboard:starlette \
-            ghcr.io/br3ndonland/inboard:starlette-"$PY_TAG"
+            ghcr.io/br3ndonland/inboard:starlette"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:starlette"$PYTHON_TAG$ALPINE_TAG"
           docker tag \
-            ghcr.io/br3ndonland/inboard:fastapi \
-            ghcr.io/br3ndonland/inboard:fastapi-"$PY_TAG"
-          docker push ghcr.io/br3ndonland/inboard:base-"$PY_TAG"
-          docker push ghcr.io/br3ndonland/inboard:starlette-"$PY_TAG"
-          docker push ghcr.io/br3ndonland/inboard:fastapi-"$PY_TAG"
+            ghcr.io/br3ndonland/inboard:fastapi"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:fastapi"$PYTHON_TAG$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:base"$PYTHON_TAG$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:starlette"$PYTHON_TAG$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:fastapi"$PYTHON_TAG$ALPINE_TAG"
       - name: Tag and push Docker images with Git tag
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           GIT_TAG=$(echo ${{ github.ref }} | cut -d / -f 3)
-          PY_TAG=python${{ matrix.python-version }}
           docker tag \
-            ghcr.io/br3ndonland/inboard:base \
-            ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"
+            ghcr.io/br3ndonland/inboard:base"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:base-"$GIT_TAG$ALPINE_TAG"
           docker tag \
-            ghcr.io/br3ndonland/inboard:starlette \
-            ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"
+            ghcr.io/br3ndonland/inboard:starlette"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG$ALPINE_TAG"
           docker tag \
-            ghcr.io/br3ndonland/inboard:fastapi \
-            ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"
+            ghcr.io/br3ndonland/inboard:fastapi"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG$ALPINE_TAG"
           docker tag \
-            ghcr.io/br3ndonland/inboard:base \
-            ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"-"$PY_TAG"
+            ghcr.io/br3ndonland/inboard:base"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:base"-$GIT_TAG$PYTHON_TAG$ALPINE_TAG"
           docker tag \
-            ghcr.io/br3ndonland/inboard:starlette \
-            ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"-"$PY_TAG"
+            ghcr.io/br3ndonland/inboard:starlette"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:starlette"-$GIT_TAG$PYTHON_TAG$ALPINE_TAG"
           docker tag \
-            ghcr.io/br3ndonland/inboard:fastapi \
-            ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"-"$PY_TAG"
-          docker push ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"
-          docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"
-          docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"
-          docker push ghcr.io/br3ndonland/inboard:base-"$GIT_TAG"-"$PY_TAG"
-          docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG"-"$PY_TAG"
-          docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG"-"$PY_TAG"
+            ghcr.io/br3ndonland/inboard:fastapi"$ALPINE_TAG" \
+            ghcr.io/br3ndonland/inboard:fastapi"-$GIT_TAG$PYTHON_TAG$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:base-"$GIT_TAG$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:base-"$GIT_TAG$PYTHON_TAG$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:starlette-"$GIT_TAG$PYTHON_TAG$ALPINE_TAG"
+          docker push ghcr.io/br3ndonland/inboard:fastapi-"$GIT_TAG$PYTHON_TAG$ALPINE_TAG"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PYTHON_VERSION=3.9
-FROM python:${PYTHON_VERSION} AS base
+ARG PYTHON_VERSION=3.9 ALPINE_VERSION=
+FROM python:${PYTHON_VERSION}${ALPINE_VERSION:+-$ALPINE_VERSION} AS base
 LABEL org.opencontainers.image.authors="Brendon Smith <bws@bws.bio>"
 LABEL org.opencontainers.image.description="Docker images and utilities to power your Python APIs and help you ship faster."
 LABEL org.opencontainers.image.licenses="MIT"
@@ -9,7 +9,8 @@ LABEL org.opencontainers.image.url="https://github.com/br3ndonland/inboard/pkgs/
 ENV APP_MODULE=inboard.app.main_base:app PATH=/opt/poetry/bin:$PATH POETRY_HOME=/opt/poetry POETRY_VIRTUALENVS_CREATE=false PYTHONPATH=/app
 COPY poetry.lock pyproject.toml /app/
 WORKDIR /app/
-RUN curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/HEAD/get-poetry.py && \
+RUN wget -qO get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/HEAD/get-poetry.py && \
+  sh -c '. /etc/os-release; if [ "$ID" = "alpine" ]; then apk add --no-cache --virtual .build-deps gcc libc-dev make; fi' && \
   python get-poetry.py -y && poetry install --no-dev --no-interaction --no-root
 COPY inboard /app/inboard
 ENTRYPOINT ["python"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -2,34 +2,43 @@
 
 ## Pull images
 
-Docker images are stored in [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (GHCR), which is a Docker registry like Docker Hub. Public Docker images can be pulled anonymously from `ghcr.io`.
+Docker images are stored in [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (GHCR), which is a Docker registry like Docker Hub. Public Docker images can be pulled anonymously from `ghcr.io`. The inboard images are based on the [official Python Docker images](https://hub.docker.com/_/python).
 
-Simply running `docker pull ghcr.io/br3ndonland/inboard` will pull the latest FastAPI image (Docker uses the `latest` tag by default). If specific versions of inboard or Python are desired, append the version numbers to the specified Docker tags as shown below _(new in inboard version 0.6.0)_.
+Simply running `docker pull ghcr.io/br3ndonland/inboard` will pull the latest FastAPI image (Docker uses the `latest` tag by default). If specific versions of inboard or Python are desired, append the version numbers to the specified Docker tags as shown below _(new in inboard version 0.6.0)_. All the available images are also provided with [Alpine Linux](https://alpinelinux.org/) builds, which are available by appending `-alpine` _(new in inboard version 0.11.0)_.
 
-```sh
-# Pull latest FastAPI image
-docker pull ghcr.io/br3ndonland/inboard
+!!! info "Available Docker tags"
 
-# Pull latest version of each image
-docker pull ghcr.io/br3ndonland/inboard:base
-docker pull ghcr.io/br3ndonland/inboard:fastapi
-docker pull ghcr.io/br3ndonland/inboard:starlette
+    ```sh
+    # Pull latest FastAPI image (Docker automatically appends the `latest` tag)
+    docker pull ghcr.io/br3ndonland/inboard
 
-# Pull image from specific release
-docker pull ghcr.io/br3ndonland/inboard:base-0.6.0
-docker pull ghcr.io/br3ndonland/inboard:fastapi-0.6.0
-docker pull ghcr.io/br3ndonland/inboard:starlette-0.6.0
+    # Pull latest version of each image
+    docker pull ghcr.io/br3ndonland/inboard:base
+    docker pull ghcr.io/br3ndonland/inboard:fastapi
+    docker pull ghcr.io/br3ndonland/inboard:starlette
 
-# Pull image with specific Python version
-docker pull ghcr.io/br3ndonland/inboard:base-python3.8
-docker pull ghcr.io/br3ndonland/inboard:fastapi-python3.8
-docker pull ghcr.io/br3ndonland/inboard:starlette-python3.8
+    # Pull image from specific release (new in inboard 0.6.0)
+    docker pull ghcr.io/br3ndonland/inboard:base-0.6.0
+    docker pull ghcr.io/br3ndonland/inboard:fastapi-0.6.0
+    docker pull ghcr.io/br3ndonland/inboard:starlette-0.6.0
 
-# Pull image from specific release and with specific Python version
-docker pull ghcr.io/br3ndonland/inboard:base-0.6.0-python3.8
-docker pull ghcr.io/br3ndonland/inboard:fastapi-0.6.0-python3.8
-docker pull ghcr.io/br3ndonland/inboard:starlette-0.6.0-python3.8
-```
+    # Pull image with specific Python version
+    docker pull ghcr.io/br3ndonland/inboard:base-python3.8
+    docker pull ghcr.io/br3ndonland/inboard:fastapi-python3.8
+    docker pull ghcr.io/br3ndonland/inboard:starlette-python3.8
+
+    # Pull image from specific release and with specific Python version
+    docker pull ghcr.io/br3ndonland/inboard:base-0.6.0-python3.8
+    docker pull ghcr.io/br3ndonland/inboard:fastapi-0.6.0-python3.8
+    docker pull ghcr.io/br3ndonland/inboard:starlette-0.6.0-python3.8
+
+    # Append `-alpine` to any of the above for Alpine Linux (new in inboard 0.11.0)
+    docker pull ghcr.io/br3ndonland/inboard:latest-alpine
+    docker pull ghcr.io/br3ndonland/inboard:fastapi-alpine
+    docker pull ghcr.io/br3ndonland/inboard:fastapi-0.11.0-alpine
+    docker pull ghcr.io/br3ndonland/inboard:fastapi-python3.8-alpine
+    docker pull ghcr.io/br3ndonland/inboard:fastapi-0.11.0-python3.8-alpine
+    ```
 
 ## Use images in a _Dockerfile_
 


### PR DESCRIPTION
## Description

This PR will add support for [Alpine Linux](https://alpinelinux.org/), based on the distribution provided by the [official Python Docker images](https://hub.docker.com/_/python).

## Changes

- Add support for Alpine Linux to Dockerfile (c7d83e7)
- Add support for Alpine Linux to GitHub Actions (a442b9f)
- Document support for Alpine Linux (41ae8b6)

## Related

tiangolo/uvicorn-gunicorn-docker#19
tiangolo/uvicorn-gunicorn-docker#22
tiangolo/uvicorn-gunicorn-docker#33
tiangolo/uvicorn-gunicorn-docker#45
tiangolo/uvicorn-gunicorn-docker#65
tiangolo/uvicorn-gunicorn-docker#72
tiangolo/uvicorn-gunicorn-fastapi-docker#18
tiangolo/uvicorn-gunicorn-fastapi-docker#31
tiangolo/uvicorn-gunicorn-fastapi-docker#53
tiangolo/uvicorn-gunicorn-fastapi-docker#61

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
