### PR TITLE
Upgrade to Uvicorn 0.15 and implement new reload options

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -196,7 +196,7 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
     !!! note
         Auto-reloading is useful for local development. [Watchgod](https://github.com/samuelcolvin/watchgod) was added as an optional dependency in [Uvicorn 0.11.4](https://github.com/encode/uvicorn/releases/tag/0.11.4), and is included with inboard.
 
-`RELOAD_DIRS`
+`RELOAD_DIRS` _(new in inboard 0.7)_
 
 -   Directories and files to watch for changes with [watchgod](https://github.com/samuelcolvin/watchgod), formatted as comma-separated string.
 -   Default: watch all directories under project root.
@@ -211,6 +211,44 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
         On the command-line, this [Uvicorn setting](https://www.uvicorn.org/settings/) is configured by passing `--reload-dir`, and can be passed multiple times, with one directory each.
 
         However, when running Uvicorn programmatically, `uvicorn.run` accepts a list of strings (`uvicorn.run(reload_dirs=["dir1", "dir2"])`), so inboard will parse the environment variable, send the list to Uvicorn, and watchgod will watch each directory or file specified.
+
+`RELOAD_DELAY` _(new in inboard 0.11)_
+
+-   Floating point value specifying the time, in seconds, to wait before reloading files.
+-   Default: not set (the value is set by `uvicorn.config.Config`)
+-   Custom: `"0.5"`
+
+    <!-- prettier-ignore -->
+    !!! note
+
+        - `uvicorn.run` equivalent: `reload_delay`
+        - Uvicorn CLI equivalent: `--reload-delay`
+
+`RELOAD_EXCLUDES` _(new in inboard 0.11)_
+
+-   Glob pattern indicating files to exclude when watching for changes with watchgod, formatted as comma-separated string.
+-   Default: not set (the value is set by `uvicorn.config.Config`)
+-   Custom: `"*[Dd]ockerfile"`
+
+    <!-- prettier-ignore -->
+    !!! note
+
+        - Parsed into a list of strings in the same manner as for `RELOAD_DIRS`.
+        - `uvicorn.run` equivalent: `reload_excludes`
+        - Uvicorn CLI equivalent: `--reload-exclude`
+
+`RELOAD_INCLUDES` _(new in inboard 0.11)_
+
+-   Glob pattern indicating files to include when watching for changes with watchgod, formatted as comma-separated string.
+-   Default: not set (the value is set by `uvicorn.config.Config`)
+-   Custom: `"*.py, *.md"`
+
+    <!-- prettier-ignore -->
+    !!! note
+
+        - Parsed into a list of strings in the same manner as for `RELOAD_DIRS`.
+        - `uvicorn.run` equivalent: `reload_includes`
+        - Uvicorn CLI equivalent: `--reload-include`
 
 ## Logging
 

--- a/inboard/start.py
+++ b/inboard/start.py
@@ -49,16 +49,23 @@ def set_gunicorn_options(app_module: str) -> list:
     return ["gunicorn", "-k", worker_class, "-c", gunicorn_conf_path, app_module]
 
 
+def _split_uvicorn_option(option: str) -> Optional[list]:
+    return (
+        [d.lstrip() for d in str(os.getenv(option.upper())).split(sep=",")]
+        if os.getenv(option.upper())
+        else None
+    )
+
+
 def set_uvicorn_options(log_config: Optional[dict] = None) -> dict:
     """Set options for running the Uvicorn server."""
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "80"))
     log_level = os.getenv("LOG_LEVEL", "info")
-    reload_dirs = (
-        [d.lstrip() for d in str(os.getenv("RELOAD_DIRS")).split(sep=",")]
-        if os.getenv("RELOAD_DIRS")
-        else None
-    )
+    reload_delay = float(value) if (value := os.getenv("RELOAD_DELAY")) else None
+    reload_dirs = _split_uvicorn_option("RELOAD_DIRS")
+    reload_excludes = _split_uvicorn_option("RELOAD_EXCLUDES")
+    reload_includes = _split_uvicorn_option("RELOAD_INCLUDES")
     use_reload = (
         True
         if (value := os.getenv("WITH_RELOAD")) and value.lower() == "true"
@@ -69,8 +76,11 @@ def set_uvicorn_options(log_config: Optional[dict] = None) -> dict:
         port=port,
         log_config=log_config,
         log_level=log_level,
-        reload_dirs=reload_dirs,
         reload=use_reload,
+        reload_delay=reload_delay,
+        reload_dirs=reload_dirs,
+        reload_excludes=reload_excludes,
+        reload_includes=reload_includes,
     )
 
 

--- a/inboard/start.py
+++ b/inboard/start.py
@@ -66,11 +66,8 @@ def set_uvicorn_options(log_config: Optional[dict] = None) -> dict:
     reload_dirs = _split_uvicorn_option("RELOAD_DIRS")
     reload_excludes = _split_uvicorn_option("RELOAD_EXCLUDES")
     reload_includes = _split_uvicorn_option("RELOAD_INCLUDES")
-    use_reload = (
-        True
-        if (value := os.getenv("WITH_RELOAD")) and value.lower() == "true"
-        else False
-    )
+    use_reload = bool((value := os.getenv("WITH_RELOAD")) and value.lower() == "true")
+
     return dict(
         host=host,
         port=port,

--- a/poetry.lock
+++ b/poetry.lock
@@ -730,15 +730,15 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.14.0"
+version = "0.15.0"
 description = "The lightning-fast ASGI server."
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-asgiref = ">=3.3.4"
-click = ">=7"
+asgiref = ">=3.4.0"
+click = ">=7.0"
 colorama = {version = ">=0.4", optional = true, markers = "sys_platform == \"win32\" and extra == \"standard\""}
 h11 = ">=0.8"
 httptools = {version = ">=0.2.0,<0.3.0", optional = true, markers = "extra == \"standard\""}
@@ -830,7 +830,7 @@ starlette = ["starlette"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "8600923459c8adeb819ba9216d1d82513ebfbca22a46a531cd4c1314304674a6"
+content-hash = "97b09263fe31a7362a7298e7451d0964d36cfbd0532b88fcc04dca7ca667d897"
 
 [metadata.files]
 appdirs = [
@@ -1314,8 +1314,8 @@ urllib3 = [
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
 ]
 uvicorn = [
-    {file = "uvicorn-0.14.0-py3-none-any.whl", hash = "sha256:2a76bb359171a504b3d1c853409af3adbfa5cef374a4a59e5881945a97a93eae"},
-    {file = "uvicorn-0.14.0.tar.gz", hash = "sha256:45ad7dfaaa7d55cab4cd1e85e03f27e9d60bc067ddc59db52a2b0aeca8870292"},
+    {file = "uvicorn-0.15.0-py3-none-any.whl", hash = "sha256:17f898c64c71a2640514d4089da2689e5db1ce5d4086c2d53699bf99513421c1"},
+    {file = "uvicorn-0.15.0.tar.gz", hash = "sha256:d9a3c0dd1ca86728d3e235182683b4cf94cd53a867c288eaeca80ee781b2caff"},
 ]
 uvloop = [
     {file = "uvloop-0.15.3-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:e71fb9038bfcd7646ca126c5ef19b17e48d4af9e838b2bcfda7a9f55a6552a32"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 gunicorn = "^20"
-uvicorn = {version = "^0.14", extras = ["standard"]}
+uvicorn = {version = "^0.15", extras = ["standard"]}
 fastapi = {version = "^0.68", optional = true}
 starlette = {version = "^0.14", optional = true}
 toml = {version = ">=0.10", optional = true}


### PR DESCRIPTION
## Description

PR #21 implemented the Uvicorn `reload_dirs` setting, enabling file watching and hot-reloading with [watchgod](https://github.com/samuelcolvin/watchgod) for development.

In encode/uvicorn#820 and [Uvicorn 0.15](https://github.com/encode/uvicorn/releases/tag/0.15.0), additional reload configuration options were added:

- `reload_delay` (CLI equivalent: `--reload-delay`)
- `reload_excludes` (CLI equivalent: `--reload-exclude`)
- `reload_includes` (CLI equivalent: `--reload-include`)

This PR will implement the new Uvicorn reload options. The options will be configured with the following environment variables:

- `RELOAD_DELAY`
- `RELOAD_EXCLUDES`
- `RELOAD_INCLUDES`

## Changes

- Upgrade to Uvicorn 0.15 (ffb47df)
- Implement new Uvicorn 0.15 reload config options (f4428dd)
- Document new Uvicorn 0.15 reload config options (95fe201)
- Update #39 with Sourcery refactorings from #40 (75b81a4)

## Related

br3ndonland/inboard#21
encode/uvicorn#820
https://github.com/encode/uvicorn/releases/tag/0.15.0

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
