### PR TITLE
Add `UVICORN_CONFIG_OPTIONS` environment variable for catch-all configuration

### DIFF
--- a/inboard/start.py
+++ b/inboard/start.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import importlib.util
+import json
 import logging
 import os
 import subprocess
@@ -67,7 +68,7 @@ def set_uvicorn_options(log_config: Optional[dict] = None) -> dict:
     reload_excludes = _split_uvicorn_option("RELOAD_EXCLUDES")
     reload_includes = _split_uvicorn_option("RELOAD_INCLUDES")
     use_reload = bool((value := os.getenv("WITH_RELOAD")) and value.lower() == "true")
-    return dict(
+    uvicorn_config_options = dict(
         host=host,
         port=port,
         log_config=log_config,
@@ -78,6 +79,10 @@ def set_uvicorn_options(log_config: Optional[dict] = None) -> dict:
         reload_excludes=reload_excludes,
         reload_includes=reload_includes,
     )
+    if value := os.getenv("UVICORN_CONFIG_OPTIONS"):
+        uvicorn_config_options_json = json.loads(value)
+        return {**uvicorn_config_options, **uvicorn_config_options_json}
+    return uvicorn_config_options
 
 
 def start_server(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,3 +165,35 @@ def pre_start_script_tmp_sh(tmp_path: Path) -> Path:
 def settings() -> Settings:
     """Instantiate a _pydantic_ Settings model for testing."""
     return Settings()
+
+
+@pytest.fixture(scope="session")
+def uvicorn_options_default() -> dict:
+    """Return default options used by `uvicorn.run()` for use in test assertions."""
+    return dict(
+        host="0.0.0.0",
+        port=80,
+        log_config=None,
+        log_level="info",
+        reload=False,
+        reload_delay=None,
+        reload_dirs=None,
+        reload_excludes=None,
+        reload_includes=None,
+    )
+
+
+@pytest.fixture
+def uvicorn_options_custom(logging_conf_dict: dict) -> dict:
+    """Return custom options used by `uvicorn.run()` for use in test assertions."""
+    return dict(
+        host="0.0.0.0",
+        port=80,
+        log_config=logging_conf_dict,
+        log_level="debug",
+        reload=True,
+        reload_delay=0.5,
+        reload_dirs=["inboard", "tests"],
+        reload_excludes=["*[Dd]ockerfile"],
+        reload_includes=["*.py", "*.md"],
+    )

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -208,6 +208,37 @@ class TestSetUvicornOptions:
         result = start.set_uvicorn_options(log_config=logging_conf_dict)
         assert result == uvicorn_options_custom
 
+    def test_set_uvicorn_options_default_from_json(
+        self,
+        uvicorn_options_default: dict,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Assert that the correct Uvicorn server options are set, in the correct order,
+        when the `UVICORN_CONFIG_OPTIONS` environment variable is also set.
+        """
+        uvicorn_options_json = (
+            '{"host": "0.0.0.0", "port": 80, "log_config": null, '
+            '"log_level": "info", "reload": false}'
+        )
+        monkeypatch.setenv("UVICORN_CONFIG_OPTIONS", uvicorn_options_json)
+        monkeypatch.setenv("WITH_RELOAD", "true")
+        result = start.set_uvicorn_options()
+        assert result == uvicorn_options_default
+
+    def test_set_uvicorn_options_custom_from_json(
+        self,
+        uvicorn_options_custom: dict,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Assert that the correct Uvicorn server options are set, in the correct order,
+        when the `UVICORN_CONFIG_OPTIONS` environment variable is also set.
+        """
+        uvicorn_options_json = start.json.dumps(uvicorn_options_custom)
+        monkeypatch.setenv("UVICORN_CONFIG_OPTIONS", uvicorn_options_json)
+        monkeypatch.setenv("WITH_RELOAD", "false")
+        result = start.set_uvicorn_options()
+        assert result == uvicorn_options_custom
+
 
 class TestStartServer:
     """Start Uvicorn and Gunicorn servers using the method in `start.py`.

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -176,7 +176,7 @@ class TestSetUvicornOptions:
     ---
     """
 
-    uvicorn_options_custom = (
+    uvicorn_options_custom_environment_variables = (
         ("LOG_LEVEL", "debug"),
         ("WITH_RELOAD", "true"),
         ("RELOAD_DELAY", "0.5"),
@@ -185,41 +185,28 @@ class TestSetUvicornOptions:
         ("RELOAD_INCLUDES", "*.py, *.md"),
     )
 
-    def test_set_uvicorn_options_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_set_uvicorn_options_default(
+        self,
+        uvicorn_options_default: dict,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test default Uvicorn server options."""
         monkeypatch.setenv("WITH_RELOAD", "false")
         result = start.set_uvicorn_options()
-        assert result == dict(
-            host="0.0.0.0",
-            port=80,
-            log_config=None,
-            log_level="info",
-            reload=False,
-            reload_dirs=None,
-            reload_delay=None,
-            reload_excludes=None,
-            reload_includes=None,
-        )
+        assert result == uvicorn_options_default
 
     def test_set_uvicorn_options_custom(
-        self, logging_conf_dict: dict, monkeypatch: pytest.MonkeyPatch
+        self,
+        logging_conf_dict: dict,
+        uvicorn_options_custom: dict,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test custom Uvicorn server options."""
-        for option in self.uvicorn_options_custom:
-            key, value = option
+        for environment_variable in self.uvicorn_options_custom_environment_variables:
+            key, value = environment_variable
             monkeypatch.setenv(key, value)
         result = start.set_uvicorn_options(log_config=logging_conf_dict)
-        assert result == dict(
-            host="0.0.0.0",
-            port=80,
-            log_config=logging_conf_dict,
-            log_level="debug",
-            reload=True,
-            reload_delay=0.5,
-            reload_dirs=["inboard", "tests"],
-            reload_excludes=["*[Dd]ockerfile"],
-            reload_includes=["*.py", "*.md"],
-        )
+        assert result == uvicorn_options_custom
 
 
 class TestStartServer:


### PR DESCRIPTION
## Description

Gunicorn supports a `GUNICORN_CMD_ARGS` catch-all environment variable for [configuring settings](https://docs.gunicorn.org/en/stable/settings.html). It looks for the `GUNICORN_CMD_ARGS` environment variable automatically, and gives these settings precedence over other environment variables and Gunicorn config files.

It would be useful to have something similar for Uvicorn. This PR will add support for a `UVICORN_CONFIG_OPTIONS` environment variable. The idea here is to allow a catch-all Uvicorn config variable in the spirit of `GUNICORN_CMD_ARGS`, so that advanced users can specify the full range of Uvicorn options even if inboard has not directly implemented them. The `inboard.start` module will run the `UVICORN_CONFIG_OPTIONS` environment variable value through `json.loads()`, and then pass the resultant dictionary through to Uvicorn. If the same option is set with an individual environment variable (such as `WITH_RELOAD`) and with a JSON value in `UVICORN_CONFIG_OPTIONS`, the JSON value will take precedence.

`json.loads()` converts data types from JSON to Python, and returns a Python dictionary. See the guide to [understanding JSON schema](https://json-schema.org/understanding-json-schema/index.html) for many helpful examples of how JSON data types correspond to Python data types. If the Uvicorn options are already available as a Python dictionary, dump them to a JSON-formatted string with `json.dumps()`, and set that as an environment variable.

The `UVICORN_CONFIG_OPTIONS` environment variable is suggested for advanced usage, because it requires some knowledge of `uvicorn.config.Config`. Other than the JSON -> Python dictionary conversion, no additional type conversions or validations are performed on `UVICORN_CONFIG_OPTIONS`. All options should be able to be passed directly to `uvicorn.config.Config`.

## Changes

- Use pytest fixtures for test Uvicorn configs (2964358)
- Implement `UVICORN_CONFIG_OPTIONS` variable (a8773b6)
- Document `UVICORN_CONFIG_OPTIONS` variable (509b4bf)

## Related

br3ndonland/inboard#21
br3ndonland/inboard#39

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
