### PR TITLE
Found some typos while browsing the docs.

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -243,11 +243,11 @@ Change the port numbers to run multiple containers simultaneously (`-p 81:80`).
 -   **Branch protection is enabled on `develop` and `main`.**
     -   `develop`:
         -   Require signed commits
-        -   Include adminstrators
+        -   Include administrators
         -   Allow force pushes
     -   `main`:
         -   Require signed commits
-        -   Include adminstrators
+        -   Include administrators
         -   Do not allow force pushes
         -   Require status checks to pass before merging (commits must have previously been pushed to `develop` and passed all checks)
 -   **To create a release:**


### PR DESCRIPTION
adminstrators => administrators

## Description

This repository needs:
A couple typo fixes in docs/contributing.
Line 246 adminstrators => administrators
Line 250 adminstrators => administrators

The commits in this pull request will:
Fix two typos in docs/contributing.

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
