### PR TITLE
Pin and test Poetry version

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -8,14 +8,17 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 
+env:
+  POETRY_HOME: /opt/poetry
+  POETRY_VERSION: 1.1.7
+  POETRY_VIRTUALENVS_CREATE: false
+
 jobs:
   python:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8, 3.9]
-    env:
-      POETRY_VIRTUALENVS_CREATE: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -38,9 +41,18 @@ jobs:
       - name: Install Poetry
         run: |
           curl -fsS -o get-poetry.py \
-            https://raw.githubusercontent.com/python-poetry/poetry/HEAD/get-poetry.py
+            "https://raw.githubusercontent.com/python-poetry/poetry/$POETRY_VERSION/get-poetry.py"
           python get-poetry.py -y
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+          echo "$POETRY_HOME/bin" >> $GITHUB_PATH
+      - name: Test Poetry version
+        run: |
+          POETRY_VERSION_INSTALLED=$(poetry -V)
+          echo "The POETRY_VERSION environment variable is set to $POETRY_VERSION."
+          echo "The installed Poetry version is $POETRY_VERSION_INSTALLED."
+          case $POETRY_VERSION_INSTALLED in
+          *$POETRY_VERSION*) echo "Poetry version correct." ;;
+          *) echo "Poetry version incorrect." && exit 1 ;;
+          esac
       - name: Install dependencies
         run: poetry install --no-interaction -E fastapi
       - name: Run pre-commit hooks

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -95,31 +95,51 @@ jobs:
         run: |
           docker build . --rm --target base \
             --build-arg LINUX_VERSION="$LINUX_VERSION" \
+            --build-arg POETRY_VERSION="$POETRY_VERSION" \
             --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
             --cache-from python:"$PYTHON_VERSION$LINUX_TAG" \
             -t ghcr.io/br3ndonland/inboard:base"$LINUX_TAG"
           docker build . --rm --target starlette \
             --build-arg LINUX_VERSION="$LINUX_VERSION" \
+            --build-arg POETRY_VERSION="$POETRY_VERSION" \
             --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
             -t ghcr.io/br3ndonland/inboard:starlette"$LINUX_TAG"
           docker build . --rm --target fastapi \
             --build-arg LINUX_VERSION="$LINUX_VERSION" \
+            --build-arg POETRY_VERSION="$POETRY_VERSION" \
             --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
             -t ghcr.io/br3ndonland/inboard:fastapi"$LINUX_TAG"
       - name: Run Docker containers for testing
         run: |
-          docker run -d -p 80:80 \
+          docker run -d -p 80:80 --name inboard-base \
             -e "BASIC_AUTH_USERNAME=test_user" \
             -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
             ghcr.io/br3ndonland/inboard:base"$LINUX_TAG"
-          docker run -d -p 81:80 \
+          docker run -d -p 81:80 --name inboard-starlette \
             -e "BASIC_AUTH_USERNAME=test_user" \
             -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
             ghcr.io/br3ndonland/inboard:starlette"$LINUX_TAG"
-          docker run -d -p 82:80 \
+          docker run -d -p 82:80 --name inboard-fastapi \
             -e "BASIC_AUTH_USERNAME=test_user" \
             -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
             ghcr.io/br3ndonland/inboard:fastapi"$LINUX_TAG"
+      - name: Test Poetry version in Docker containers
+        run: |
+          test_poetry_version_in_docker() {
+            echo "The POETRY_VERSION environment variable is set to $POETRY_VERSION."
+            local poetry_version_in_docker
+            for container_name in "$@"; do
+              poetry_version_in_docker=$(docker exec "$container_name" poetry -V)
+              if [ -n "$poetry_version_in_docker" ]; then
+                echo "Docker container $container_name has $poetry_version_in_docker."
+              fi
+              case $poetry_version_in_docker in
+              *$POETRY_VERSION*) echo "Poetry versions match for $container_name." ;;
+              *) echo "Poetry version test failed for $container_name." && return 1 ;;
+              esac
+            done
+          }
+          test_poetry_version_in_docker inboard-base inboard-starlette inboard-fastapi
       - name: Smoke test Docker containers
         run: |
           handle_error_code() {

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -6,14 +6,17 @@ on:
     branches: [develop, main]
   workflow_dispatch:
 
+env:
+  POETRY_HOME: /opt/poetry
+  POETRY_VERSION: 1.1.7
+  POETRY_VIRTUALENVS_CREATE: false
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8, 3.9]
-    env:
-      POETRY_VIRTUALENVS_CREATE: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -35,9 +38,19 @@ jobs:
           restore-keys: ${{ runner.os }}-pre-commit-
       - name: Install Poetry
         run: |
-          curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/HEAD/get-poetry.py
+          curl -fsS -o get-poetry.py \
+            "https://raw.githubusercontent.com/python-poetry/poetry/$POETRY_VERSION/get-poetry.py"
           python get-poetry.py -y
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+          echo "$POETRY_HOME/bin" >> $GITHUB_PATH
+      - name: Test Poetry version
+        run: |
+          POETRY_VERSION_INSTALLED=$(poetry -V)
+          echo "The POETRY_VERSION environment variable is set to $POETRY_VERSION."
+          echo "The installed Poetry version is $POETRY_VERSION_INSTALLED."
+          case $POETRY_VERSION_INSTALLED in
+          *$POETRY_VERSION) echo "Poetry version correct." ;;
+          *) echo "Poetry version incorrect." && exit 1 ;;
+          esac
       - name: Install dependencies
         run: poetry install --no-interaction -E fastapi
       - name: Run pre-commit hooks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,17 @@ on:
       - "**.toml"
   workflow_dispatch:
 
+env:
+  POETRY_HOME: /opt/poetry
+  POETRY_VERSION: 1.1.7
+  POETRY_VIRTUALENVS_CREATE: false
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8, 3.9]
-    env:
-      POETRY_VIRTUALENVS_CREATE: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -32,9 +35,19 @@ jobs:
           restore-keys: ${{ runner.os }}-poetry-
       - name: Install Poetry
         run: |
-          curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/HEAD/get-poetry.py
+          curl -fsS -o get-poetry.py \
+            "https://raw.githubusercontent.com/python-poetry/poetry/$POETRY_VERSION/get-poetry.py"
           python get-poetry.py -y
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+          echo "$POETRY_HOME/bin" >> $GITHUB_PATH
+      - name: Test Poetry version
+        run: |
+          POETRY_VERSION_INSTALLED=$(poetry -V)
+          echo "The POETRY_VERSION environment variable is set to $POETRY_VERSION."
+          echo "The installed Poetry version is $POETRY_VERSION_INSTALLED."
+          case $POETRY_VERSION_INSTALLED in
+          *$POETRY_VERSION) echo "Poetry version correct." ;;
+          *) echo "Poetry version incorrect." && exit 1 ;;
+          esac
       - name: Install dependencies
         run: poetry install --no-interaction -E fastapi
       - name: Run unit tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/br3ndonland/inboard"
 LABEL org.opencontainers.image.title="inboard"
 LABEL org.opencontainers.image.url="https://github.com/br3ndonland/inboard/pkgs/container/inboard"
-ARG LINUX_VERSION
-ENV APP_MODULE=inboard.app.main_base:app LINUX_VERSION=$LINUX_VERSION PATH=/opt/poetry/bin:$PATH POETRY_HOME=/opt/poetry POETRY_VIRTUALENVS_CREATE=false PYTHONPATH=/app
+ARG LINUX_VERSION POETRY_VERSION=1.1.7
+ENV APP_MODULE=inboard.app.main_base:app LINUX_VERSION=$LINUX_VERSION PATH=/opt/poetry/bin:$PATH POETRY_HOME=/opt/poetry POETRY_VERSION=$POETRY_VERSION POETRY_VIRTUALENVS_CREATE=false PYTHONPATH=/app
 COPY poetry.lock pyproject.toml /app/
 WORKDIR /app/
 RUN sh -c 'if [ "$LINUX_VERSION" = "slim" ]; then apt-get update -qy && apt-get install -qy --no-install-recommends gcc libc-dev make wget; fi' && \
-  wget -qO get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/HEAD/get-poetry.py && \
+  wget -qO get-poetry.py "https://raw.githubusercontent.com/python-poetry/poetry/$POETRY_VERSION/get-poetry.py" && \
   sh -c '. /etc/os-release; if [ "$ID" = "alpine" ]; then apk add --no-cache --virtual .build-deps gcc libc-dev make; fi' && \
   python get-poetry.py -y && poetry install --no-dev --no-interaction --no-root && \
   sh -c 'if [ "$LINUX_VERSION" = "slim" ]; then apt-get purge --auto-remove -qy gcc libc-dev make wget; fi' && \


### PR DESCRIPTION
## Description

Poetry has introduced a number of problematic changes recently. To help buffer against these problematic changes, this PR will implement installation and testing of specific versions of Poetry, rather than the latest version.

## Changes

The following steps will be taken to verify the Poetry version, both when installing Poetry on the GitHub Actions runner, and when installing Poetry in Docker container images:

1. Set the `POETRY_VERSION` environment variable, which should be used by the _get-poetry.py_ and _install-poetry.py_ install scripts to install the specified version
2. Download the Poetry install script from the GitHub repo at a specific Git tag by templating the `POETRY_VERSION` environment variable into the URL
3. Run a shell test to assert that the Poetry version returned by the `poetry -V` command matches `POETRY_VERSION` (in case the install script stops correctly reading `POETRY_VERSION`, for example)

Commits:

- Pin and test Poetry version in GitHub Actions (a38617d)
- Pin and test Poetry version in Docker (036b57c)

## Related

br3ndonland/inboard#36
python-poetry/poetry#3870
python-poetry/poetry#4210
python-poetry/poetry#4429

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
