### PR TITLE
Add configurable logging filter

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -309,6 +309,19 @@ The idea here is to allow a catch-all Uvicorn config variable in the spirit of `
     -   `LOG_COLORS="true"`
     -   `LOG_COLORS="false"`
 
+`LOG_FILTERS`
+
+-   Comma-separated string identifying log records to filter out. The string will be split on commas and converted to a set. Each log message will then be checked for each filter in the set. If any matches are present in the log message, the logger will not log that message.
+-   Default: `None` (don't filter out any log records, just log every record)
+-   Custom: `LOG_FILTERS="/health, /heartbeat"` (filter out log messages that contain either the string `"/health"` or the string `"/heartbeat"`, to avoid logging health checks)
+-   See also:
+    -   [AWS Builders' Library: Implementing health checks](https://aws.amazon.com/builders-library/implementing-health-checks/)
+    -   [AWS Elastic Load Balancing docs: Target groups - Health checks for your target groups](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html)
+    -   [benoitc/gunicorn#1781](https://github.com/benoitc/gunicorn/issues/1781)
+    -   [Python 3 docs: How-To - Logging Cookbook - Using Filters to impart contextual information](https://docs.python.org/3/howto/logging-cookbook.html#using-filters-to-impart-contextual-information)
+    -   [Python 3 docs: What's new in Python 3.2 - logging](https://docs.python.org/3/whatsnew/3.2.html#logging)
+    -   [Django 4.0 docs: Topics - Logging](https://docs.djangoproject.com/en/4.0/topics/logging/)
+
 `LOG_FORMAT`
 
 -   [Python logging format](https://docs.python.org/3/library/logging.html#formatter-objects).

--- a/inboard/__init__.py
+++ b/inboard/__init__.py
@@ -13,10 +13,11 @@ try:
     from .app.utilities_starlette import BasicAuth as StarletteBasicAuth
 except ImportError:  # pragma: no cover
     pass
-from .logging_conf import LOGGING_CONFIG, configure_logging
+from .logging_conf import LOGGING_CONFIG, LogFilter, configure_logging
 
 __all__ = (
     "LOGGING_CONFIG",
+    "LogFilter",
     "StarletteBasicAuth",
     "configure_logging",
     "fastapi_basic_auth",

--- a/inboard/logging_conf.py
+++ b/inboard/logging_conf.py
@@ -4,7 +4,7 @@ import logging.config
 import os
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Set
 
 
 def find_and_load_logging_conf(logging_conf: str) -> dict:
@@ -48,6 +48,62 @@ def configure_logging(
         raise
 
 
+class LogFilter(logging.Filter):
+    """Subclass of `logging.Filter` used to filter log messages.
+    ---
+
+    Filters identify log messages to filter out, so that the logger does not log
+    messages containing any of the filters. If any matches are present in a log
+    message, the logger will not output the message.
+
+    The environment variable `LOG_FILTERS` can be used to specify filters as a
+    comma-separated string, like `LOG_FILTERS="/health, /heartbeat"`. To then
+    add the filters to a class instance, the `LogFilter.set_filters()`
+    method can produce the set of filters from the environment variable value.
+    """
+
+    __slots__ = "name", "nlen", "filters"
+
+    def __init__(
+        self,
+        name: str = "",
+        filters: Optional[Set[str]] = None,
+    ) -> None:
+        """Initialize a filter."""
+        self.name = name
+        self.nlen = len(name)
+        self.filters = filters
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Determine if the specified record is to be logged.
+
+        Returns True if the record should be logged, or False otherwise.
+        """
+        if self.filters is None:
+            return True
+        message = record.getMessage()
+        return not any(match in message for match in self.filters)
+
+    @staticmethod
+    def set_filters(input_filters: Optional[str] = None) -> Optional[Set[str]]:
+        """Set log message filters.
+
+        Filters identify log messages to filter out, so that the logger does not
+        log messages containing any of the filters. The argument to this method
+        should be supplied as a comma-separated string. The string will be split
+        on commas and converted to a set of strings.
+
+        This method is provided as a `staticmethod`, instead of as part of `__init__`,
+        so that it only runs once when setting the `LOG_FILTERS` module-level constant.
+        In contrast, the `__init__` method runs each time a logger is instantiated.
+        """
+        return (
+            {log_filter.strip() for log_filter in str(log_filters).split(sep=",")}
+            if (log_filters := input_filters or os.getenv("LOG_FILTERS"))
+            else None
+        )
+
+
 LOG_COLORS = (
     True
     if (value := os.getenv("LOG_COLORS")) and value.lower() == "true"
@@ -55,11 +111,15 @@ LOG_COLORS = (
     if value and value.lower() == "false"
     else sys.stdout.isatty()
 )
+LOG_FILTERS = LogFilter.set_filters()
 LOG_FORMAT = str(os.getenv("LOG_FORMAT", "simple"))
 LOG_LEVEL = str(os.getenv("LOG_LEVEL", "info")).upper()
 LOGGING_CONFIG: dict = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "filter_log_message": {"()": LogFilter, "filters": LOG_FILTERS},
+    },
     "formatters": {
         "simple": {
             "class": "logging.Formatter",
@@ -87,6 +147,7 @@ LOGGING_CONFIG: dict = {
     "handlers": {
         "default": {
             "class": "logging.StreamHandler",
+            "filters": ["filter_log_message"],
             "formatter": LOG_FORMAT,
             "level": LOG_LEVEL,
             "stream": "ext://sys.stdout",

--- a/inboard/logging_conf.py
+++ b/inboard/logging_conf.py
@@ -82,7 +82,7 @@ class LogFilter(logging.Filter):
         if self.filters is None:
             return True
         message = record.getMessage()
-        return not any(match in message for match in self.filters)
+        return all(match not in message for match in self.filters)
 
     @staticmethod
     def set_filters(input_filters: Optional[str] = None) -> Optional[Set[str]]:

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -258,11 +258,16 @@ class TestSetUvicornOptions:
     def test_set_uvicorn_options_custom_from_json(
         self,
         uvicorn_options_custom: dict,
+        mocker: MockerFixture,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Assert that the correct Uvicorn server options are set, in the correct order,
         when the `UVICORN_CONFIG_OPTIONS` environment variable is also set.
+
+        The `LOGGING_CONFIG` dictionary can't be encoded as a JSON string when it has
+        a class definition (the filter class), so the "filters" dict has to be removed.
         """
+        mocker.patch.dict(uvicorn_options_custom["log_config"]["filters"], clear=True)
         uvicorn_options_json = start.json.dumps(uvicorn_options_custom)
         monkeypatch.setenv("UVICORN_CONFIG_OPTIONS", uvicorn_options_json)
         monkeypatch.setenv("WITH_RELOAD", "false")


### PR DESCRIPTION
## Description

When applications with APIs are deployed, it is common to perform "health checks" on them. Health checks are usually performed by making HTTP requests to a designated API endpoint. These checks are made at frequent intervals, and so they can fill up the access logs with large numbers of unnecessary log records.

To avoid logging health checks, it would be helpful to have a way to filter health checks out of the logs.

## Changes

This PR will add a configurable logging filter to `inboard.logging_conf`.

- Filters can be provided as a comma-separated string with the environment variable `LOG_FILTERS`, like `LOG_FILTERS="/health, /heartbeat"`.
- The environment variable value will be converted into a set of strings.
- Each log message will then be checked for each filter in the set. If any matches are present in the log message, the logger will not log that message.

There are multiple ways to match these filters. inboard simply performs a substring membership check to see if any of the filters in the set have a match in the log message. This should work for most use cases, but the match could be overly greedy. For example, if `/health` is in `LOG_FILTERS`, it would filter out calls to `/health`, but it would also filter out calls to `/healthy`.

Another approach could be to operate on the `LogRecord` args, but the results would vary based on how the program supplies the log record.

- As seen in the [type stubs for the `logging` module](https://github.com/python/typeshed/blob/e719f5443270128fc78651cde9b05c3cee01261c/stdlib/logging/__init__.pyi#L59-L62), the args can be either `tuple[object, ...]` or `Mapping[str, object]`. The args could be converted to a set, and compared with the set of filters using `isdisjoint`. This set comparison approach is potentially more precise than string matching.
- Gunicorn's access logger `gunicorn.access` supports several custom message fields, which it calls "atoms" in its source code, and "identifiers" in the [docs](https://docs.gunicorn.org/en/latest/settings.html#logging). Gunicorn [formats these atoms](https://github.com/benoitc/gunicorn/blob/933b210f2eff943f4cd9502c676f3d93c82f171c/gunicorn/glogging.py#L277-L329) and [supplies them](https://github.com/benoitc/gunicorn/blob/933b210f2eff943f4cd9502c676f3d93c82f171c/gunicorn/glogging.py#L331-L351) as `LogRecord` args. The URL path could be logged with the `%(U)s` atom, and inboard could check to see if there is an exact match in the set of filters.
- Uvicorn's access logger `uvicorn.access` [automatically supplies the URL path as its own arg](https://github.com/encode/uvicorn/blob/dcc5c9681d3dfb5795dee758ba83268a0377ea17/uvicorn/_logging.py#L97-L105), which could also work nicely with this approach.
- However, `LogRecord` args aren't always supplied as strings directly, so there would probably need to be `isinstance` checks added to check each of the args. For example, when watching files with `watchgod` (now renamed to `watchfiles`), [Uvicorn logs the list of files being watched as a single arg](https://github.com/encode/uvicorn/blob/83986d822686739dc033495494ebdc88c4e266e8/uvicorn/config.py#L342-L345). Lists are not hashable, so the list would need to be converted to another type (like `set`, or `str` as the logger does when formatting messages) in order to perform equality comparisons.

Substring membership checks should be adequate for this feature, and they avoid the complications of working with `LogRecord` args directly.

## Related

- benoitc/gunicorn#1781
- [Python 3 docs: How-To - Logging Cookbook - Using Filters to impart contextual information](https://docs.python.org/3/howto/logging-cookbook.html#using-filters-to-impart-contextual-information)
- [Python 3 docs: What's new in Python 3.2 - logging](https://docs.python.org/3/whatsnew/3.2.html#logging)
- [Django 4.0 docs: How-to - Logging](https://docs.djangoproject.com/en/4.0/howto/logging/)
- [Django 4.0 docs: Reference - Logging](https://docs.djangoproject.com/en/4.0/ref/logging/)
- [Django 4.0 docs: Topics - Logging](https://docs.djangoproject.com/en/4.0/topics/logging/)
- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
