### PR TITLE
Use BuildKit for Docker builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -115,7 +115,7 @@ jobs:
             --build-arg PIPX_VERSION="$PIPX_VERSION" \
             --build-arg POETRY_VERSION="$POETRY_VERSION" \
             --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
-            --cache-from python:"$PYTHON_VERSION$LINUX_TAG" \
+            --cache-from ghcr.io/br3ndonland/inboard \
             -t ghcr.io/br3ndonland/inboard:base"$LINUX_TAG"
           docker build . --rm --target starlette \
             --build-arg BUILDKIT_INLINE_CACHE=1 \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Build Docker images
         run: |
           docker build . --rm --target base \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
             --build-arg LINUX_VERSION="$LINUX_VERSION" \
             --build-arg PIPX_VERSION="$PIPX_VERSION" \
             --build-arg POETRY_VERSION="$POETRY_VERSION" \
@@ -117,12 +118,14 @@ jobs:
             --cache-from python:"$PYTHON_VERSION$LINUX_TAG" \
             -t ghcr.io/br3ndonland/inboard:base"$LINUX_TAG"
           docker build . --rm --target starlette \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
             --build-arg LINUX_VERSION="$LINUX_VERSION" \
             --build-arg PIPX_VERSION="$PIPX_VERSION" \
             --build-arg POETRY_VERSION="$POETRY_VERSION" \
             --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
             -t ghcr.io/br3ndonland/inboard:starlette"$LINUX_TAG"
           docker build . --rm --target fastapi \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
             --build-arg LINUX_VERSION="$LINUX_VERSION" \
             --build-arg PIPX_VERSION="$PIPX_VERSION" \
             --build-arg POETRY_VERSION="$POETRY_VERSION" \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 env:
+  DOCKER_BUILDKIT: "1"
   PIPX_VERSION: "1.1.0"
   POETRY_VERSION: "1.1.11"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.title="inboard"
 LABEL org.opencontainers.image.url="https://github.com/br3ndonland/inboard/pkgs/container/inboard"
 ARG LINUX_VERSION PIPX_VERSION=1.1.0 POETRY_VERSION=1.1.11
 ENV APP_MODULE=inboard.app.main_base:app LINUX_VERSION=$LINUX_VERSION PATH=/opt/pipx/bin:/app/.venv/bin:$PATH PIPX_BIN_DIR=/opt/pipx/bin PIPX_HOME=/opt/pipx/home PIPX_VERSION=$PIPX_VERSION POETRY_VERSION=$POETRY_VERSION PYTHONPATH=/app
-COPY poetry.lock poetry.toml pyproject.toml /app/
+COPY --link poetry.lock poetry.toml pyproject.toml /app/
 WORKDIR /app
 RUN <<HEREDOC
 . /etc/os-release
@@ -25,7 +25,7 @@ python -m pip install --no-cache-dir --upgrade pip "pipx==$PIPX_VERSION"
 pipx install "poetry==$POETRY_VERSION"
 poetry install --no-dev --no-interaction --no-root
 HEREDOC
-COPY inboard /app/inboard
+COPY --link inboard /app/inboard
 ENTRYPOINT ["python"]
 CMD ["-m", "inboard.start"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1
 ARG PYTHON_VERSION=3.10 LINUX_VERSION=
 FROM python:${PYTHON_VERSION}${LINUX_VERSION:+-$LINUX_VERSION} AS builder
 LABEL org.opencontainers.image.authors="Brendon Smith <bws@bws.bio>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 ARG PYTHON_VERSION=3.10 LINUX_VERSION=
-FROM python:${PYTHON_VERSION}${LINUX_VERSION:+-$LINUX_VERSION} AS base
+FROM python:${PYTHON_VERSION}${LINUX_VERSION:+-$LINUX_VERSION} AS builder
 LABEL org.opencontainers.image.authors="Brendon Smith <bws@bws.bio>"
 LABEL org.opencontainers.image.description="Docker images and utilities to power your Python APIs and help you ship faster."
 LABEL org.opencontainers.image.licenses="MIT"
@@ -12,9 +12,7 @@ ENV APP_MODULE=inboard.app.main_base:app LINUX_VERSION=$LINUX_VERSION PATH=/opt/
 COPY poetry.lock poetry.toml pyproject.toml /app/
 WORKDIR /app
 RUN <<HEREDOC
-
 . /etc/os-release
-
 if [ "$ID" = "alpine" ]; then
   apk add --no-cache --virtual .build-deps \
     gcc libc-dev libffi-dev make openssl-dev
@@ -23,27 +21,47 @@ elif [ "$LINUX_VERSION" = "slim" ]; then
   apt-get install -qy --no-install-recommends \
     gcc libc-dev make wget
 fi
-
 python -m pip install --no-cache-dir --upgrade pip "pipx==$PIPX_VERSION"
 pipx install "poetry==$POETRY_VERSION"
 poetry install --no-dev --no-interaction --no-root
+HEREDOC
+COPY inboard /app/inboard
+ENTRYPOINT ["python"]
+CMD ["-m", "inboard.start"]
 
+FROM builder as base
+RUN <<HEREDOC
+. /etc/os-release
 if [ "$ID" = "alpine" ]; then
   apk del .build-deps
 elif [ "$LINUX_VERSION" = "slim" ]; then
   apt-get purge --auto-remove -qy \
     gcc libc-dev make wget
 fi
-
 HEREDOC
-COPY inboard /app/inboard
-ENTRYPOINT ["python"]
-CMD ["-m", "inboard.start"]
 
-FROM base AS fastapi
+FROM builder AS fastapi
 ENV APP_MODULE=inboard.app.main_fastapi:app
-RUN poetry install --no-dev --no-interaction --no-root -E fastapi
+RUN <<HEREDOC
+poetry install --no-dev --no-interaction --no-root -E fastapi
+. /etc/os-release
+if [ "$ID" = "alpine" ]; then
+  apk del .build-deps
+elif [ "$LINUX_VERSION" = "slim" ]; then
+  apt-get purge --auto-remove -qy \
+    gcc libc-dev make wget
+fi
+HEREDOC
 
-FROM base AS starlette
+FROM builder AS starlette
 ENV APP_MODULE=inboard.app.main_starlette:app
-RUN poetry install --no-dev --no-interaction --no-root -E starlette
+RUN <<HEREDOC
+poetry install --no-dev --no-interaction --no-root -E starlette
+. /etc/os-release
+if [ "$ID" = "alpine" ]; then
+  apk del .build-deps
+elif [ "$LINUX_VERSION" = "slim" ]; then
+  apt-get purge --auto-remove -qy \
+    gcc libc-dev make wget
+fi
+HEREDOC

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -167,12 +167,16 @@ docker cp [container_name]:/path/to/file destination.file
 
 ### Building development images
 
+Note that Docker builds use BuildKit. See the [BuildKit docs](https://github.com/moby/buildkit/blob/HEAD/frontend/dockerfile/docs/syntax.md) and [Docker docs](https://docs.docker.com/develop/develop-images/build_enhancements/).
+
 To build the Docker images for each stage:
 
 ```sh
 git clone git@github.com:br3ndonland/inboard.git
 
 cd inboard
+
+export DOCKER_BUILDKIT=1
 
 docker build . --rm --target base -t localhost/br3ndonland/inboard:base && \
 docker build . --rm --target fastapi -t localhost/br3ndonland/inboard:fastapi && \

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -241,7 +241,7 @@ The basic build dependencies used by inboard include `gcc`, `libc-dev`, and `mak
 !!! example "Example Alpine Linux _Dockerfile_ for PostgreSQL project"
 
     ```dockerfile
-    # syntax=docker/dockerfile:1.4
+    # syntax=docker/dockerfile:1
     ARG INBOARD_DOCKER_TAG=fastapi-alpine
     FROM ghcr.io/br3ndonland/inboard:${INBOARD_DOCKER_TAG}
     ENV APP_MODULE=mypackage.main:app
@@ -292,7 +292,7 @@ A _Dockerfile_ equivalent to the Alpine Linux example might look like the follow
 !!! example "Example Debian Linux slim _Dockerfile_ for PostgreSQL project"
 
     ```dockerfile
-    # syntax=docker/dockerfile:1.4
+    # syntax=docker/dockerfile:1
     ARG INBOARD_DOCKER_TAG=fastapi-slim
     FROM ghcr.io/br3ndonland/inboard:${INBOARD_DOCKER_TAG}
     ENV APP_MODULE=mypackage.main:app

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -241,14 +241,29 @@ The basic build dependencies used by inboard include `gcc`, `libc-dev`, and `mak
 !!! example "Example Alpine Linux _Dockerfile_ for PostgreSQL project"
 
     ```dockerfile
+    # syntax=docker/dockerfile:1.4
     ARG INBOARD_DOCKER_TAG=fastapi-alpine
     FROM ghcr.io/br3ndonland/inboard:${INBOARD_DOCKER_TAG}
     ENV APP_MODULE=mypackage.main:app
     COPY poetry.lock pyproject.toml /app/
     WORKDIR /app
-    RUN sh -c '. /etc/os-release; if [ "$ID" = "alpine" ]; then apk add --no-cache --virtual .build-project build-base freetype-dev gcc libc-dev libpng-dev make openblas-dev postgresql-dev; fi' && \
-      poetry install --no-dev --no-interaction --no-root && \
-      sh -c '. /etc/os-release; if [ "$ID" = "alpine" ]; then apk del .build-project && apk add --no-cache libpq; fi'
+    RUN <<HEREDOC
+
+    . /etc/os-release
+
+    if [ "$ID" = "alpine" ]; then
+      apk add --no-cache --virtual .build-project \
+        build-base freetype-dev gcc libc-dev libpng-dev make openblas-dev postgresql-dev
+    fi
+
+    poetry install --no-dev --no-interaction --no-root
+
+    if [ "$ID" = "alpine" ]; then
+      apk del .build-project
+      apk add --no-cache libpq
+    fi
+
+    HEREDOC
     COPY mypackage /app/mypackage
     ```
 
@@ -277,18 +292,47 @@ A _Dockerfile_ equivalent to the Alpine Linux example might look like the follow
 !!! example "Example Debian Linux slim _Dockerfile_ for PostgreSQL project"
 
     ```dockerfile
+    # syntax=docker/dockerfile:1.4
     ARG INBOARD_DOCKER_TAG=fastapi-slim
     FROM ghcr.io/br3ndonland/inboard:${INBOARD_DOCKER_TAG}
     ENV APP_MODULE=mypackage.main:app
     COPY poetry.lock pyproject.toml /app/
     WORKDIR /app
     ARG INBOARD_DOCKER_TAG
-    RUN sh -c '. /etc/os-release; if [ "$ID" = "debian" ] && echo "$INBOARD_DOCKER_TAG" | grep -q "slim"; then apt-get update -qy && apt-get install -qy --no-install-recommends gcc libc-dev libpq-dev make wget; fi' && \
-      poetry install --no-dev --no-interaction --no-root && \
-      sh -c '. /etc/os-release; if [ "$ID" = "debian" ] && echo "$INBOARD_DOCKER_TAG" | grep -q "slim"; then apt-get purge --auto-remove -qy gcc libc-dev make wget; fi'
+    RUN <<HEREDOC
+
+    . /etc/os-release
+
+    if [ "$ID" = "debian" ] && echo "$INBOARD_DOCKER_TAG" | grep -q "slim"; then
+      apt-get update -qy
+      apt-get install -qy --no-install-recommends \
+        gcc libc-dev make wget
+    fi
+
+    poetry install --no-dev --no-interaction --no-root
+
+    if [ "$ID" = "debian" ] && echo "$INBOARD_DOCKER_TAG" | grep -q "slim"; then
+      apt-get purge --auto-remove -qy \
+        gcc libc-dev make wget
+    fi
+
+    HEREDOC
     COPY mypackage /app/mypackage
     ```
 
 !!! info "Redeclaring Docker build arguments"
 
     Why is `ARG INBOARD_DOCKER_TAG` repeated in the example above? To understand this, it is necessary to [understand how `ARG` and `FROM` interact](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact). Any `ARG`s before `FROM` are outside the Docker build context. In order to use them again inside the build context, they must be redeclared.
+
+!!! tip "Here-documents in Dockerfiles"
+
+    The `RUN` commands in the Dockerfiles above use a special syntax called a [here-document](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07), or "heredoc". This syntax allows multiple lines of text to be passed into a shell command, enabling Dockerfile `RUN` commands to be written like shell scripts, instead of having to jam commands into long run-on lines. Heredoc support was added to Dockerfiles in the [1.4.0 release](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.4.0).
+
+    For more info, see:
+
+    -   [br3ndonland/inboard#54](https://github.com/br3ndonland/inboard/pull/54)
+    -   [BuildKit docs: Dockerfile frontend syntaxes](https://github.com/moby/buildkit/blob/HEAD/frontend/dockerfile/docs/syntax.md)
+    -   [BuildKit releases: dockerfile/1.4.0](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.4.0)
+    -   [Docker blog 2021-07-30: Introduction to heredocs in Dockerfiles](https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/)
+    -   [Docker docs: Develop with Docker - Build images with BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/)
+    -   [Docker docs: Dockerfile reference - BuildKit](https://docs.docker.com/engine/reference/builder/#buildkit)


### PR DESCRIPTION
## Description

This PR will update Docker builds to use BuildKit, a next-generation build back-end that can be used with front-ends including `buildctl`, `docker`, and `docker buildx`.

BuildKit supports some helpful [features](https://github.com/moby/buildkit/blob/HEAD/frontend/dockerfile/docs/syntax.md), including:

- **Heredocs**: [here-documents](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07), also known as "heredocs," allow multiple lines of text to be passed into a shell command. Heredoc support was added to Dockerfiles in the [1.4.0 release](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.4.0). This feature enables Dockerfile `RUN` commands to be written like shell scripts, instead of having to jam commands into long run-on lines.
- `COPY --link`, which allows layers to be re-used, even if layers built previously have changed
- `RUN --mount`, which allows advanced mounting and caching of files during builds, as well as access to secrets without baking the secrets into the final image layers
- `RUN --network`, which allows advanced networking configuration

In addition to the `buildctl` front-end, Docker confusingly offers two front-end options for working with the BuildKit back-end:

1. [`DOCKER_BUILDKIT=1 docker build`](https://docs.docker.com/develop/develop-images/build_enhancements/), using the same Docker CLI commands as usual, but with BuildKit as a back-end instead of the legacy (but [apparently not deprecated](https://docs.docker.com/engine/deprecated/)) build back-end
2. [`docker buildx build`](https://docs.docker.com/buildx/working-with-buildx/), invoking a Docker CLI plugin which also uses BuildKit as a back-end

The differences between these two options are poorly-documented, and it is unclear why the Buildx features aren't included in the mainline Docker CLI. The `DOCKER_BUILDKIT=1 docker build` option will be used.

## Changes

### Dockerfile

- Refactor Dockerfile with heredoc syntax
  - The contents of the `RUN` command were previously added to the `base` stage to support Alpine Linux (br3ndonland/inboard#37) and Debian "slim" Linux (br3ndonland/inboard#38).
  - Split the previous `base` stage into `builder` and `base` stages (the `builder` name comes from the "builder" pattern discussed in the [Docker docs](https://docs.docker.com/develop/develop-images/multistage-build/))
  - In the `builder` stage, install build-time dependencies and Python packages (but don't uninstall the build-time dependencies yet, as the previous `RUN` command did)
  - In the `base`, `starlette`, and `fastapi` stages, start with `FROM builder`, install any additional packages, and then uninstall build-time dependencies
- Break heredoc across multiple stages
  - Previously, build-time dependencies for building Python packages with binary extensions were installed and uninstalled in one `RUN` command, as they were only [needed to install some dependencies on Alpine Linux](https://inboard.bws.bio/docker#linux-distributions). However, this also meant that build-time dependencies were not available to later installation steps, such as installing FastAPI dependencies. The FastAPI dependency _pydantic_ has binary extensions, and although it now provides wheels with the `musllinux` tag (for Alpine), inboard should account for the possibility that packages like _pydantic_ might need to build from source.
  - This PR will refactor build-time dependency installation into two steps. The dependencies will be installed in the new `builder` stage, then uninstalled at the end of each subsequent stage.
- Use `COPY --link` to improve layer caching
  - `COPY --link` allows re-use of layers, even when layers built previously have changed.

### `docker build` command

- Enable BuildKit in GitHub Actions
  - The `DOCKER_BUILDKIT=1 docker build` option will be used.
- Add `BUILDKIT_INLINE_CACHE` Docker build argument
  - The [`BUILDKIT_INLINE_CACHE` build argument](https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources) tells Docker to write cache metadata into the image during `docker build`. The image can then be used as a cache source for subsequent builds.
  - The build argument will be provided with the `docker build` command. The build argument could be provided directly within the Dockerfile, but BuildKit does not offer clear guidance on where it goes. It could either be supplied before the first `FROM`, or after the first `FROM`, and could work differently in each case.
  - There have been some minor issues with the `BUILDKIT_INLINE_CACHE` build argument, but they shouldn't be a concern for this project.
    - moby/buildkit#1876
    - moby/buildkit#1981
- Update `docker build --cache-from` for inboard
  - `--cache-from` allows build commands to [specify external cache sources](https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources).
  - The Docker build was previously caching from the official Python image.
  - With the BuildKit inline cache metadata provided by images built with `BUILDKIT_INLINE_CACHE=1`, layers from inboard can now also be cached.
  - The inboard caching may not kick in until after this PR is merged, because images must first be pushed to the registry before the cache metadata can be read.
  - The standard caching mechanism may not be effective for the multi-stage builds used here, so `--cache-from` may not end up reducing build times. See notes section for additional info on caching in GitHub Actions.

### Docs

- Add Docker BuildKit info to CONTRIBUTING.md
- Add heredoc examples and info to docs

### TODOs

- [x] ~~Build Starlette and FastAPI images concurrently?~~
- [x] Figure out which combo of back-end and front-end to use
- [x] ~~Use the GitHub Actions external cache source?~~

## Notes

### Build concurrency

BuildKit automatically runs build stages concurrently when possible. Unfortunately, tags can't be specified for intermediate stages/targets, and inboard needs to specify tags for each stage. Docker recommends multiple builds for multiple targets, so inboard will continue using separate build commands for each stage.

- https://github.com/moby/buildkit/issues/797#issuecomment-460385530 ("multiple builds for multiple targets")
- docker/buildx#98
- [Docker blog 2020-04-20: Advanced Dockerfiles](https://www.docker.com/blog/advanced-dockerfiles-faster-builds-and-smaller-images-using-buildkit-and-multistage-builds/)

### GitHub Actions external cache source

At this time, the caching APIs are confusing and experimental. There are three different caching APIs, two cache export modes, and four "exporters."

Caching APIs:

1. The Docker CLI offers a `--cache-from` flag. `--cache-from` allows build commands to [specify external cache sources](https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources). The docs on use of this flag are confusing and poorly written, but it appears that this option uses `min` caching mode, which does not cache intermediate stages.
2. The BuildKit `buildctl` front-end offers different flags, `--export-cache` and `--import-cache`, which apparently support at least two modes and at least four "exporters."
   1. Modes:
      1. `mode=min`. The [BuildKit README says](https://github.com/moby/buildkit/blob/f4eb826799e53547c793bfa83a035b8e24a2b88d/README.md#github-actions-cache-experimental) `min` only caches layers from the final image, and not from intermediate build stages.
      2. `mode=max`. This mode can read layer data from intermediate stages in multi-stage builds.
   2. Exporters
      1. `inline`: "embed the cache into the image, and push them to the registry together" (isn't this specified by `BUILDKIT_INLINE_CACHE=1`?)
      2. `gha`: "export to GitHub Actions cache"
      3. `local`: "export to a local directory"
      4. `registry`: "push the image and the cache separately"
3. Buildx (which uses BuildKit) offers ` --cache-from` as the Docker CLI does, but accepts different values, and also offers a `--cache-to` flag that apparently supports `mode=min` and `mode=max`.

In addition to deciphering the confusing caching APIs, there are other considerations needed:

- Registry authentication steps may need to be adjusted. In order to use image layers in a registry as cache sources, either the images must be public and the registry must allow anonymous pulls (which GHCR does, see [docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry) and [blog](https://github.blog/2021-06-21-github-packages-container-registry-generally-available/)), or registry login must occur before running `docker build`.
- In GitHub Actions, there have been issues with the cache growing and growing.
  - docker/build-push-action#252
  - moby/buildkit#1850
  - moby/buildkit#1857
  - moby/buildkit#1896
- Use of external caching with Buildx in GitHub Actions requires the strange, undocumented [crazy-max/ghaction-github-runtime](https://github.com/crazy-max/ghaction-github-runtime) action "to expose GitHub runtime to the workflow."
  - docker/buildx#744

Trying to figure out all the confusion around caching takes inordinate amounts of human time, and in the case of this project, would only save negligible amounts of machine time (without caching, Docker builds only take 1-3 minutes of machine time). Not worth it at all.

## Related

- [BuildKit docs: Dockerfile frontend syntaxes](https://github.com/moby/buildkit/blob/f4eb826799e53547c793bfa83a035b8e24a2b88d/frontend/dockerfile/docs/syntax.md)
- [BuildKit docs: Dockerfile reference](https://github.com/moby/buildkit/blob/f4eb826799e53547c793bfa83a035b8e24a2b88d/frontend/dockerfile/docs/reference.md)
- [BuildKit README: GitHub Actions cache (experimental)](https://github.com/moby/buildkit/blob/f4eb826799e53547c793bfa83a035b8e24a2b88d/README.md#github-actions-cache-experimental)
- [BuildKit releases: dockerfile/1.4.0](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.4.0)
- [Docker blog 2020-04-20: Advanced Dockerfiles](https://www.docker.com/blog/advanced-dockerfiles-faster-builds-and-smaller-images-using-buildkit-and-multistage-builds/)
- [Docker blog 2021-07-30: Introduction to heredocs in Dockerfiles](https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/)
- [Docker docs: CLI - `docker build` - Specifying external cache sources](https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources)
- [Docker docs: Develop with Docker - Build images with BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/)
- [Docker docs: Develop with Docker - Use multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/)
- [Docker docs: Dockerfile reference - BuildKit](https://docs.docker.com/engine/reference/builder/#buildkit)
- [Docker docs: Docker Engine - Docker Buildx](https://docs.docker.com/buildx/working-with-buildx/)
- [inboard docs: Docker images - Linux distributions](https://inboard.bws.bio/docker#linux-distributions)
- [POSIX standard: Shell Command Language - Redirection (here-documents)](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_07)
- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
