### PR TITLE
Break up `uvicorn[standard]` optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "gunicorn>=20,<21",
-  "uvicorn[standard]>=0.17,<0.18",
+  "uvicorn>=0.17,<0.18",
 ]
 description = "Docker images and utilities to power your Python APIs and help you ship faster."
 dynamic = ["version"]
@@ -57,6 +57,14 @@ tests = [
   "pytest-mock>=3,<4",
   "pytest-timeout>=1,<2",
 ]
+uvicorn-fast = [
+  "httptools>=0.4.0",
+  "uvloop>=0.14.0,!=0.15.0,!=0.15.1; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",
+  "websockets>=10.0",
+]
+uvicorn-standard = [
+  "uvicorn[standard]>=0.17,<0.18",
+]
 
 [project.urls]
 Docker = "https://github.com/br3ndonland/inboard/pkgs/container/inboard"
@@ -86,6 +94,7 @@ features = [
   "checks",
   "fastapi",
   "tests",
+  "uvicorn-fast",
 ]
 path = ".venv"
 
@@ -96,6 +105,7 @@ features = [
   "docs",
   "fastapi",
   "tests",
+  "uvicorn-fast",
 ]
 path = ".venv"
 


### PR DESCRIPTION
## Description

Uvicorn lumps several optional dependencies into a "standard" extra:

- `colorama` (for Windows)
- `httptools`
- `python-dotenv`
- `pyyaml`
- `uvloop`
- `watchgod`/`watchfiles` (`watchgod` was renamed to `watchfiles`)
- `websockets`

There has been some discussion about the drawbacks of this approach:

- encode/uvicorn#219
- encode/uvicorn#1274
- encode/uvicorn#1547

inboard has previously installed the "standard" extra by default.

## Changes

### BREAKING CHANGE to default installation

This PR will change the default to installing Uvicorn without "standard." This is a **BREAKING CHANGE** to inboard's dependencies.

### `inboard[uvicorn-fast]`

A new `inboard[uvicorn-fast]` extra will be added for dependencies from `uvicorn[standard]` related to web server performance, and can be installed by specifying the extra when installing inboard, like `python -m pip install 'inboard[fastapi,uvicorn-fast]'`:

- `httptools`
- `uvloop`
- `websockets`

### `inboard[uvicorn-standard]`

For users who still need all the `uvicorn[standard]` extras, a new `inboard[uvicorn-standard]` extra will be added to the inboard package, and can be installed by specifying the extra when installing inboard, like `python -m pip install 'inboard[fastapi,uvicorn-standard]'`.

## Related

- encode/uvicorn#219
- encode/uvicorn#1274
- encode/uvicorn#1547
- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
