### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -64,7 +64,7 @@ jobs:
           *) echo "Incorrect Hatch virtualenv." && exit 1 ;;
           esac
       - name: Test that Git tag version and Python package version match
-        if: github.ref_type == 'tag' && matrix.python-version == '3.10'
+        if: github.ref_type == 'tag' && matrix.python-version == '3.11'
         run: |
           GIT_TAG_VERSION=$GITHUB_REF_NAME
           PACKAGE_VERSION=$(hatch version)
@@ -91,7 +91,7 @@ jobs:
       - name: Build Python package
         run: hatch build
       - name: Publish Python package to PyPI
-        if: github.ref_type == 'tag' && matrix.python-version == '3.10'
+        if: github.ref_type == 'tag' && matrix.python-version == '3.11'
         run: hatch publish -n -u __token__ -a ${{ secrets.PYPI_TOKEN }}
   docker:
     runs-on: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         linux-version: ["", "alpine", "slim"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -244,7 +244,7 @@ jobs:
             -u ${{ github.actor }} --password-stdin
       - name: Tag and push Docker images with latest tags
         if: >
-          matrix.python-version == '3.10' &&
+          matrix.python-version == '3.11' &&
           (
             github.ref_type == 'tag' ||
             github.ref == 'refs/heads/develop' ||

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: github/codeql-action/init@v2
         with:
           languages: python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION=3.10 LINUX_VERSION=
+ARG PYTHON_VERSION=3.11 LINUX_VERSION=
 FROM python:${PYTHON_VERSION}${LINUX_VERSION:+-$LINUX_VERSION} AS builder
 LABEL org.opencontainers.image.authors="Brendon Smith <bws@bws.bio>"
 LABEL org.opencontainers.image.description="Docker images and utilities to power your Python APIs and help you ship faster."

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -26,10 +26,10 @@ Please see [inboard Git tags](https://github.com/br3ndonland/inboard/tags), [inb
     docker pull ghcr.io/br3ndonland/inboard:0.38-fastapi
 
     # Pull image with specific Python version
-    docker pull ghcr.io/br3ndonland/inboard:fastapi-python3.10
+    docker pull ghcr.io/br3ndonland/inboard:fastapi-python3.11
 
     # Pull image from latest minor release and with specific Python version
-    docker pull ghcr.io/br3ndonland/inboard:0.38-fastapi-python3.10
+    docker pull ghcr.io/br3ndonland/inboard:0.38-fastapi-python3.11
 
     # Append `-alpine` to image tags for Alpine Linux (new in inboard 0.11.0)
     docker pull ghcr.io/br3ndonland/inboard:latest-alpine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Topic :: Internet :: Log Analysis",
   "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
   "Topic :: Internet :: WWW/HTTP :: WSGI",


### PR DESCRIPTION
## Description

This PR will add [Python 3.11](https://docs.python.org/3/whatsnew/3.11.html) support to inboard.

## Changes

### Code changes

- Add Python 3.11 to GitHub Actions workflows
- Add Python 3.11 classifier to _pyproject.toml_
- Set Python 3.11 as default version in _Dockerfile_

### Results

- inboard will now run tests with Python 3.11, in addition to 3.8-3.10
- inboard will now build and publish its PyPI package using Python 3.11
- inboard will now include a Python 3.11 classifier in its PyPI package
- inboard will now ship Docker images running Python 3.11, in addition to 3.8-3.10, and Docker images tagged with `latest` will now use 3.11

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).

Related projects that have released support for Python 3.11 include, in alphabetical order:

- [FastAPI 0.86.0](https://github.com/tiangolo/fastapi/releases/tag/0.86.0) (2022-11-03)
- [Hatch 1.1.2](https://github.com/pypa/hatch/releases/tag/hatch-v1.1.2) (2022-05-20)
- [_pydantic_ 1.10.0](https://github.com/pydantic/pydantic/releases/tag/v1.10.0) (2022-08-30)
- [Starlette 0.21.0](https://github.com/encode/starlette/releases/tag/0.21.0) (2022-09-26)
- [Uvicorn 0.19.0](https://github.com/encode/uvicorn/releases/tag/0.19.0) (2022-10-19)

Related projects that have not released support for Python 3.11 include:

- [Gunicorn](https://github.com/benoitc/gunicorn) (has not released or tested Python 3.11 support)
- [`pipx`](https://github.com/pypa/pipx) (has not released Python 3.11 support, but is testing with Python 3.11 in development)
