### PR TITLE
Use Ruff for linting and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ _Docker images and utilities to power your Python APIs and help you ship faster.
 
 [![PyPI](https://img.shields.io/pypi/v/inboard?color=success)](https://pypi.org/project/inboard/)
 [![GitHub Container Registry](https://img.shields.io/badge/github%20container%20registry-inboard-success)](https://github.com/br3ndonland/inboard/pkgs/container/inboard)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://black.readthedocs.io/en/stable/)
 [![coverage](https://img.shields.io/badge/coverage-100%25-brightgreen?logo=pytest&logoColor=white)](https://coverage.readthedocs.io/en/latest/)
 [![builds](https://github.com/br3ndonland/inboard/workflows/builds/badge.svg)](https://github.com/br3ndonland/inboard/actions)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/ef2798f758e03fa659d1ba2973ddd59515400978/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 [![Mentioned in Awesome FastAPI](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/mjhea0/awesome-fastapi)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -204,15 +204,7 @@ Code quality checks can be run using the Hatch scripts in _pyproject.toml_.
 
 ### Code style
 
--   **Python code is formatted with [Black](https://black.readthedocs.io/en/stable/)**. Configuration for Black is stored in _[pyproject.toml](https://github.com/br3ndonland/inboard/blob/HEAD/pyproject.toml)_.
--   **Python imports are organized automatically with [isort](https://pycqa.github.io/isort/)**.
-    -   The isort package organizes imports in three sections:
-        1. Standard library
-        2. Dependencies
-        3. Project
-    -   Within each of those groups, `import` statements occur first, then `from` statements, in alphabetical order.
-    -   You can run isort from the command line with `hatch run isort .`.
-    -   Configuration for isort is stored in _[pyproject.toml](https://github.com/br3ndonland/inboard/blob/HEAD/pyproject.toml)_.
+-   Python code is formatted with [Ruff](https://docs.astral.sh/ruff/). Ruff configuration is stored in _pyproject.toml_.
 -   Other web code (JSON, Markdown, YAML) is formatted with [Prettier](https://prettier.io/).
 
 ### Static type checking

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -77,10 +77,8 @@ The _pyproject.toml_ could look like this:
 
     [project.optional-dependencies]
     checks = [
-      "black",
-      "flake8",
-      "isort",
       "mypy",
+      "ruff",
     ]
     docs = [
       "mkdocs-material",
@@ -133,10 +131,6 @@ The _pyproject.toml_ could look like this:
     [tool.hatch.version]
     path = "package_name/__init__.py"
 
-    [tool.isort]
-    profile = "black"
-    src_paths = ["package_name", "tests"]
-
     [tool.mypy]
     files = ["**/*.py"]
     plugins = "pydantic.mypy"
@@ -147,6 +141,16 @@ The _pyproject.toml_ could look like this:
     addopts = "-q"
     minversion = "6.0"
     testpaths = ["tests"]
+
+    [tool.ruff]
+    extend-select = ["I"]
+    src = ["package_name", "tests"]
+
+    [tool.ruff.format]
+    docstring-code-format = true
+
+    [tool.ruff.lint.isort]
+    known-first-party = ["package_name", "tests"]
 
     ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,10 +6,9 @@ _Docker images and utilities to power your Python APIs and help you ship faster.
 
 [![PyPI](https://img.shields.io/pypi/v/inboard?color=success)](https://pypi.org/project/inboard/)
 [![GitHub Container Registry](https://img.shields.io/badge/github%20container%20registry-inboard-success)](https://github.com/br3ndonland/inboard/pkgs/container/inboard)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://black.readthedocs.io/en/stable/)
 [![coverage](https://img.shields.io/badge/coverage-100%25-brightgreen?logo=pytest&logoColor=white)](https://coverage.readthedocs.io/en/latest/)
 [![builds](https://github.com/br3ndonland/inboard/workflows/builds/badge.svg)](https://github.com/br3ndonland/inboard/actions)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/ef2798f758e03fa659d1ba2973ddd59515400978/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 [![Mentioned in Awesome FastAPI](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/mjhea0/awesome-fastapi)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,8 @@ requires-python = ">=3.8.1,<4"
 
 [project.optional-dependencies]
 checks = [
-  "black>=23,<24",
-  "flake8>=6,<7",
-  "isort>=5,<6",
   "mypy==1.8.0",
+  "ruff>=0.1,<0.2",
 ]
 docs = [
   "mkdocs-material>=9,<10",
@@ -113,16 +111,15 @@ path = ".venv"
 
 [tool.hatch.envs.default.scripts]
 check = [
-  "black --check --diff .",
-  "isort --check --diff .",
-  "flake8 --extend-exclude=.venv,bin,build,cache,dist,lib --max-line-length=88",
+  "ruff check",
+  "ruff format --check",
   "mypy",
   "npx -s -y prettier@'^2' . --check",
   "npx -s -y cspell --dot --gitignore *.md **/*.md",
 ]
 format = [
-  "black .",
-  "isort .",
+  "ruff check --fix",
+  "ruff format",
   "npx -s -y prettier@'^2' . --write",
 ]
 
@@ -149,10 +146,6 @@ path = ".venv"
 [tool.hatch.version]
 path = "inboard/__init__.py"
 
-[tool.isort]
-profile = "black"
-src_paths = ["inboard", "tests"]
-
 [tool.mypy]
 files = ["**/*.py"]
 plugins = "pydantic.mypy"
@@ -163,3 +156,13 @@ strict = true
 addopts = "-q"
 minversion = "6.0"
 testpaths = ["tests"]
+
+[tool.ruff]
+extend-select = ["I"]
+src = ["inboard", "tests"]
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint.isort]
+known-first-party = ["inboard", "tests"]


### PR DESCRIPTION
## Description

[Ruff](https://docs.astral.sh/ruff/) is a Python linter and formatter that has gained popularity due to its high performance and numerous capabilities.

Now that Ruff has [released its first minor version series](https://astral.sh/blog/ruff-v0.1.0) (`0.1`) and has a [versioning policy](https://docs.astral.sh/ruff/versioning/), it's a good time to consider adopting it.

This PR will replace Black, Flake8, and isort with Ruff.

## Changes

### Black

[Ruff is a drop-in replacement for Black](https://docs.astral.sh/ruff/faq/#is-the-ruff-linter-compatible-with-black). No additional configuration is necessary.

Ruff supports opt-in [docstring formatting](https://docs.astral.sh/ruff/formatter/#docstring-formatting) with the `docstring-code-format` setting. The format is compatible with [Black string formatting](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#strings).

```toml
[tool.ruff.format]
docstring-code-format = true
```

### Flake8

[Ruff is a drop-in replacement for Flake8](https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8). No additional configuration is necessary.

In addition to replacing Flake8 itself, Ruff can also replace many Flake8 plugins and related projects.

### isort

[Ruff is not a drop-in replacement for isort](https://docs.astral.sh/ruff/faq/#how-does-ruffs-import-sorting-compare-to-isort) at this time. Additional configuration is needed.

1. Import sorting is opt-in. Ruff will not automatically sort imports. The [`extend-select` setting](https://docs.astral.sh/ruff/settings/#extend-select) is needed with the [`I` ruleset](https://docs.astral.sh/ruff/rules/#isort-i).
2. There is no [`src_paths` setting](https://pycqa.github.io/isort/docs/configuration/options.html#src-paths). The [`src` setting](https://docs.astral.sh/ruff/settings/#src) and the [`known-first-party` setting](https://docs.astral.sh/ruff/settings/#isort-known-first-party) are used instead. The [Ruff FAQ](https://docs.astral.sh/ruff/faq/#how-does-ruff-determine-which-of-my-imports-are-first-party-third-party-etc) currently says, "Ruff accepts a `src` option that in your `pyproject.toml`, `ruff.toml`, or `.ruff.toml` file, which specifies the directories that Ruff should consider when determining whether an import is first-party," making it sound like only `src` would be needed. However, to match isort behavior, both `src` and `known-first-party` may need to be set to the same list of directories.
3. Although isort is a formatter, Ruff does not run import sorting with the Ruff formatter. The Ruff linter is used instead (`ruff check --fix`).

Taken together, Ruff configuration settings in `pyproject.toml` related to import sorting look like this:

```toml
[tool.ruff]
extend-select = ["I"]
src = ["package_name", "tests"]

[tool.ruff.lint.isort]
known-first-party = ["package_name", "tests"]
```

### Notes on additional tools

#### Hatch

[Hatch 1.8.0](https://hatch.pypa.io/latest/blog/2023/12/11/hatch-v180/#static-analysis) introduced static analysis with Ruff. Although this is a promising feature of Hatch, it will not be used at this time because of differences between [Hatch default settings](https://hatch.pypa.io/1.9/config/static-analysis/#default-settings) and [Ruff default settings](https://docs.astral.sh/ruff/configuration/), and because it is not yet possible to fully override the Hatch default settings (though this will likely be improved in the next release, see https://github.com/pypa/hatch/discussions/1117 and https://github.com/pypa/hatch/issues/1181).

#### VSCode

To use Ruff in VSCode, install `charliermarsh.ruff` from the [VSCode extension marketplace](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) or [Open VSX marketplace](https://open-vsx.org/extension/charliermarsh/ruff) (for [VSCodium](https://vscodium.com/)), then update `settings.json` like this:

```json
{
  "[python]": {
    "editor.codeActionsOnSave": {
      "source.fixAll": "always",
      "source.organizeImports": "always"
    },
    "editor.defaultFormatter": "charliermarsh.ruff",
    "editor.formatOnSave": true
  },
  "ruff.lint.args": ["--extend-select=I"]
}
```

## Related

- [Ruff blog: Ruff v0.1.0](https://astral.sh/blog/ruff-v0.1.0)
- [Ruff docs: FAQ](https://docs.astral.sh/ruff/faq/)
- [Ruff docs: Rules](https://docs.astral.sh/ruff/rules/)
- [Ruff docs: Settings](https://docs.astral.sh/ruff/settings/)
- [Ruff docs: The Ruff linter](https://docs.astral.sh/ruff/linter/) (`ruff check`)
- [Ruff docs: The Ruff formatter](https://docs.astral.sh/ruff/formatter/) (`ruff format`)
- [Ruff docs: Versioning](https://docs.astral.sh/ruff/versioning/)
- [Hatch blog 2023-12-11: Hatch v1.8.0](https://hatch.pypa.io/latest/blog/2023/12/11/hatch-v180/#hatchling)
- [Hatch docs: Static analysis](https://hatch.pypa.io/latest/config/static-analysis/)
- https://github.com/pypa/hatch/discussions/1117
- https://github.com/pypa/hatch/issues/1181
