### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -93,7 +93,7 @@ jobs:
           *) echo "Incorrect Hatch virtualenv." && exit 1 ;;
           esac
       - name: Test that Git tag version and Python package version match
-        if: github.ref_type == 'tag' && matrix.python-version == '3.11'
+        if: github.ref_type == 'tag' && matrix.python-version == '3.12'
         run: |
           GIT_TAG_VERSION=$GITHUB_REF_NAME
           PACKAGE_VERSION=$(hatch version)
@@ -115,7 +115,7 @@ jobs:
       - name: Publish Python package to PyPI
         if: >
           github.ref_type == 'tag' &&
-          matrix.python-version == '3.11' &&
+          matrix.python-version == '3.12' &&
           needs.setup.outputs.environment-name == 'PyPI'
         uses: pypa/gh-action-pypi-publish@release/v1.8
   docker:
@@ -125,7 +125,7 @@ jobs:
       fail-fast: false
       matrix:
         linux-version: ["", "alpine", "slim"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -269,7 +269,7 @@ jobs:
             -u ${{ github.actor }} --password-stdin
       - name: Tag and push Docker images with latest tags
         if: >
-          matrix.python-version == '3.11' &&
+          matrix.python-version == '3.12' &&
           (
             github.ref_type == 'tag' ||
             github.ref == 'refs/heads/develop' ||

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: github/codeql-action/init@v3
         with:
           languages: python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION=3.11 LINUX_VERSION=
+ARG PYTHON_VERSION=3.12 LINUX_VERSION=
 FROM python:${PYTHON_VERSION}${LINUX_VERSION:+-$LINUX_VERSION} AS builder
 LABEL org.opencontainers.image.authors="Brendon Smith <bws@bws.bio>"
 LABEL org.opencontainers.image.description="Docker images and utilities to power your Python APIs and help you ship faster."

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,24 +20,24 @@ Please see [inboard Git tags](https://github.com/br3ndonland/inboard/tags), [inb
     docker pull ghcr.io/br3ndonland/inboard:starlette
 
     # Pull image from specific release
-    docker pull ghcr.io/br3ndonland/inboard:0.38.0-fastapi
+    docker pull ghcr.io/br3ndonland/inboard:0.67.0-fastapi
 
     # Pull image from latest minor version release (new in inboard 0.22.0)
-    docker pull ghcr.io/br3ndonland/inboard:0.38-fastapi
+    docker pull ghcr.io/br3ndonland/inboard:0.67-fastapi
 
     # Pull image with specific Python version
-    docker pull ghcr.io/br3ndonland/inboard:fastapi-python3.11
+    docker pull ghcr.io/br3ndonland/inboard:fastapi-python3.12
 
     # Pull image from latest minor release and with specific Python version
-    docker pull ghcr.io/br3ndonland/inboard:0.38-fastapi-python3.11
+    docker pull ghcr.io/br3ndonland/inboard:0.67-fastapi-python3.12
 
     # Append `-alpine` to image tags for Alpine Linux (new in inboard 0.11.0)
     docker pull ghcr.io/br3ndonland/inboard:latest-alpine
-    docker pull ghcr.io/br3ndonland/inboard:0.38-fastapi-alpine
+    docker pull ghcr.io/br3ndonland/inboard:0.67-fastapi-alpine
 
     # Append `-slim` to any of the above for Debian slim (new in inboard 0.11.0)
     docker pull ghcr.io/br3ndonland/inboard:latest-slim
-    docker pull ghcr.io/br3ndonland/inboard:0.38-fastapi-slim
+    docker pull ghcr.io/br3ndonland/inboard:0.67-fastapi-slim
     ```
 
 ## Use images in a _Dockerfile_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Internet :: Log Analysis",
   "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
   "Topic :: Internet :: WWW/HTTP :: WSGI",


### PR DESCRIPTION
## Description

This PR will add [Python 3.12](https://docs.python.org/3/whatsnew/3.12.html) support to inboard.

## Changes

### Code changes

- Add Python 3.12 to GitHub Actions workflows
- Add Python 3.12 classifier to _pyproject.toml_
- Set Python 3.12 as default version in _Dockerfile_

### Results

- inboard will now run tests with Python 3.12, in addition to 3.8-3.11
- inboard will now build and publish its PyPI package using Python 3.12
- inboard will now include a Python 3.12 classifier in its PyPI package
- inboard will now ship Docker images running Python 3.12, in addition to 3.8-3.11, and Docker images tagged with `latest` will now use 3.12

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).

Related projects that have released support for Python 3.12 include:

- AnyIO ([4.0.0 - 2023-08-30](https://github.com/agronholm/anyio/releases/tag/4.0.0))
- FastAPI([0.109.0 - 2024-01-11](https://github.com/tiangolo/fastapi/releases/tag/0.109.0))
- Hatch ([1.8.0 - 2023-12-11](https://github.com/pypa/hatch/releases/tag/hatch-v1.8.0))
- `pipx` ([1.3.0 - 2023-12-02](https://github.com/pypa/pipx/releases/tag/1.3.0))
- Starlette ([0.31.0 - 2023-07-24](https://github.com/encode/starlette/releases/tag/0.31.0))
- Uvicorn ([0.24.0 - 2023-11-04](https://github.com/encode/uvicorn/releases/tag/0.24.0))

Related projects that have not released support for Python 3.12 include:

- [Gunicorn](https://github.com/benoitc/gunicorn) (has not released Python 3.12 support, but is testing with Python 3.12 in development)
- [Pydantic](https://github.com/pydantic/pydantic) (extent of Python 3.12 support unclear, see https://github.com/pydantic/pydantic/discussions/6704)
