### PR TITLE
Specify Debian version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linux-version: ["", "alpine", "slim"]
+        linux-version: ["alpine", "bookworm", "slim-bookworm"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

On 2023-06-14, Docker updated the default Debian Linux version in its Python official images from Debian bullseye to Debian bookworm. As inboard uses the default Debian Linux version from the Docker Python official images, this meant that the next release of inboard (0.50.0 - 2023-06-22) automatically updated to bookworm. There were some [issues](https://github.com/docker-library/python/issues?q=bookworm) noted by the community after this update.

## Changes

inboard will now specify the Debian version when building Docker images. The current Debian version is still Debian 12 ("bookworm"). The next Debian version, Debian 13 ("trixie") does not have a release date yet, but inboard will update to trixie when it is stable and will provide a new release after the update.

## Related

- https://github.com/br3ndonland/inboard/discussions/80
- [inboard docs: changelog - 0.51.0 - 2023-07-09](https://inboard.bws.bio/changelog#0510-2023-07-09)
- [docker-library/python](https://github.com/docker-library/python)
- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).
