### PR TITLE
Update to Gunicorn 25

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1321,7 +1321,15 @@
                 "code": "reportAny",
                 "range": {
                     "startColumn": 0,
-                    "endColumn": 16,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 0,
+                    "endColumn": 24,
                     "lineCount": 1
                 }
             },
@@ -1345,22 +1353,6 @@
                 "code": "reportAny",
                 "range": {
                     "startColumn": 21,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 21,
                     "endColumn": 54,
                     "lineCount": 1
                 }
@@ -1370,6 +1362,38 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 62,
                     "lineCount": 1
                 }
             },
@@ -1392,16 +1416,32 @@
             {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 14,
-                    "endColumn": 37,
+                    "startColumn": 11,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 61,
+                    "startColumn": 37,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -1418,38 +1458,6 @@
                 "range": {
                     "startColumn": 20,
                     "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -1828,32 +1836,64 @@
             {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 20,
+                    "startColumn": 12,
+                    "endColumn": 24,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 44,
+                    "startColumn": 12,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 20,
+                    "startColumn": 12,
+                    "endColumn": 24,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 39,
+                    "startColumn": 12,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
             echo "[ERROR] Unexpected .coverage files detected."
             exit 1
           fi
-        timeout-minutes: 5
+        timeout-minutes: 8
       - name: Enforce test coverage
         run: |
           hatch run ${{ env.HATCH_ENV }}:coverage combine -q
@@ -122,7 +122,6 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python3 -m pip install 'httpie>=3,<4' 'urllib3>=1,<2'
       - name: Set up versions and Docker tags for Python and Alpine Linux
         id: setup
         run: |
@@ -160,80 +159,122 @@ jobs:
             --build-arg PIPX_VERSION="$PIPX_VERSION" \
             --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
             -t ghcr.io/br3ndonland/inboard:fastapi"$LINUX_TAG"
-      - name: Run Docker containers for testing
-        run: |
-          docker run -d -p 80:80 --name inboard-base \
-            -e "BASIC_AUTH_USERNAME=test_user" \
-            -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
-            ghcr.io/br3ndonland/inboard:base"$LINUX_TAG"
-          docker run -d -p 81:80 --name inboard-starlette \
-            -e "BASIC_AUTH_USERNAME=test_user" \
-            -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
-            ghcr.io/br3ndonland/inboard:starlette"$LINUX_TAG"
-          docker run -d -p 82:80 --name inboard-fastapi \
-            -e "BASIC_AUTH_USERNAME=test_user" \
-            -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
-            ghcr.io/br3ndonland/inboard:fastapi"$LINUX_TAG"
-      - name: Test virtualenv location in Docker containers
-        run: |
-          test_virtualenv_location_in_docker() {
-            local docker_virtualenv docker_python expected_virtualenv expected_python
-            expected_virtualenv="/app/$HATCH_ENV_TYPE_VIRTUAL_PATH"
-            expected_python="$expected_virtualenv/bin/python"
-            echo "The Hatch virtualenv should be at $expected_virtualenv."
-            echo "The Python executable should be at $expected_python."
-            for container_name in "$@"; do
-              docker_virtualenv=$(docker exec "$container_name" hatch env find)
-              docker_python=$(docker exec "$container_name" which python)
-              case "$docker_virtualenv" in
-              "$expected_virtualenv") echo "Correct Hatch virtualenv $docker_virtualenv for $container_name." ;;
-              *) echo "Incorrect Hatch virtualenv $docker_virtualenv for $container_name." && return 1 ;;
-              esac
-              case "$docker_python" in
-              "$expected_python") echo "Correct Python $docker_python for $container_name." ;;
-              *) echo "Incorrect Python $docker_python for $container_name." && return 1 ;;
-              esac
-            done
-          }
-          test_virtualenv_location_in_docker inboard-base inboard-starlette inboard-fastapi
       - name: Smoke test Docker containers
         run: |
           handle_error_code() {
             case "$1" in
-            2) : 'Request timed out!' ;;
-            3) : 'Unexpected HTTP 3xx Redirection!' ;;
-            4) : 'HTTP 4xx Client Error!' ;;
-            5) : 'HTTP 5xx Server Error!' ;;
-            6) : 'Exceeded --max-redirects=<n> redirects!' ;;
-            *) : 'Other Error!' ;;
+            2) : "Request timed out" ;;
+            3) : "Unexpected HTTP 3xx redirection" ;;
+            4) : "HTTP 4xx client error" ;;
+            5) : "HTTP 5xx server error" ;;
+            6) : "Exceeded max number of redirects" ;;
+            *) : "Other error code $1" ;;
             esac
-            echo "$_"
+            echo "[ERROR] error code: $_" >&2
             return "$1"
           }
+
           smoke_test() {
-            if http --check-status --ignore-stdin -q --timeout=5 "$@"; then
-              echo 'Smoke test passed. OK!'
+            echo "[INFO] Running smoke test of $*."
+            if curl --fail --max-time 5 --no-keepalive --no-progress-meter "$@"; then
+              echo
+              echo "[INFO] Smoke test of $* passed."
             else
-              handle_error_code "$?"
+              local error_code="$?"
+              echo
+              echo "[ERROR] Smoke test of $* failed." >&2
+              handle_error_code "$error_code"
             fi
           }
+
           smoke_test_xfail() {
-            if http --check-status --ignore-stdin -q --timeout=5 "$@" &>/dev/null; then
-              echo 'Smoke test should have failed!'
-              return 1
+            echo "[INFO] Running smoke test of $* that is expected to fail."
+            if ! curl --fail --max-time 5 --no-keepalive --no-progress-meter "$@"; then
+              echo
+              echo "[INFO] Smoke test of $* expected to fail."
             else
-              echo 'Smoke test expected to fail. OK!'
+              echo
+              echo "[ERROR] Smoke test of $* should have failed!" >&2
+              return 1
             fi
           }
-          smoke_test :80
-          smoke_test :81
-          smoke_test :82
-          smoke_test -a test_user:r4ndom_bUt_memorable :81/status
-          smoke_test -a test_user:r4ndom_bUt_memorable :82/status
-          smoke_test_xfail -a test_user:incorrect_password :81/status
-          smoke_test_xfail -a test_user:incorrect_password :82/status
-          smoke_test_xfail :81/status
-          smoke_test_xfail :82/status
+
+          test_gunicorn_in_docker() {
+            local container_name=$1 expected_message
+            local -i worker_count
+            echo "[INFO] Docker container logs from $container_name:"
+            docker logs "$container_name"
+            if [[ $container_name == *asgi ]]; then
+              expected_message="Using worker: asgi"
+            else
+              expected_message="Using worker:"
+            fi
+            grep -q "$expected_message" <(docker logs "$container_name")
+            echo "[INFO] Gunicorn control interface (gunicornc) stats from $container_name:"
+            docker exec "$container_name" gunicornc -c "show stats"
+            worker_count=$(docker exec "$container_name" gunicornc -c "show stats" -j | jq -r '.workers_current')
+            if [ $worker_count -lt 1 ]; then
+              echo "[ERROR] Gunicorn control interface (gunicornc) reports $worker_count workers spawned." >&2
+              return 1
+            fi
+          }
+
+          test_virtualenv_location_in_docker() {
+            local container_name=$1 docker_virtualenv docker_python expected_virtualenv expected_python
+            expected_virtualenv="/app/$HATCH_ENV_TYPE_VIRTUAL_PATH"
+            expected_python="$expected_virtualenv/bin/python"
+            echo "[INFO] The Hatch virtualenv should be at $expected_virtualenv."
+            echo "[INFO] The Python executable should be at $expected_python."
+            docker_virtualenv=$(docker exec "$container_name" hatch env find)
+            docker_python=$(docker exec "$container_name" which python)
+            case "$docker_virtualenv" in
+            "$expected_virtualenv") echo "[INFO] Correct Hatch virtualenv $docker_virtualenv for $container_name." ;;
+            *) echo "[ERROR] Incorrect Hatch virtualenv $docker_virtualenv for $container_name." >&2 && return 1 ;;
+            esac
+            case "$docker_python" in
+            "$expected_python") echo "[INFO] Correct Python $docker_python for $container_name." ;;
+            *) echo "[ERROR] Incorrect Python $docker_python for $container_name." >&2 && return 1 ;;
+            esac
+          }
+
+          main() {
+            local container_name=$1 container_tag worker_class
+            local -i host_port=10101
+            echo "[INFO] Testing $container_name."
+            echo
+            container_tag=$(echo "$container_name" | cut -d - -f 2)
+            [[ $container_name == *asgi ]] && worker_class=asgi
+            docker run -d -p $host_port:80 --name "$container_name" \
+              -e "BASIC_AUTH_USERNAME=test_user" \
+              -e "BASIC_AUTH_PASSWORD=r4ndom_bUt_memorable" \
+              -e "LOG_FORMAT=gunicorn" \
+              -e "LOG_LEVEL=debug" \
+              ${worker_class:+-e "WORKER_CLASS=asgi"} \
+              ghcr.io/br3ndonland/inboard:"$container_tag$LINUX_TAG"
+            sleep 5
+            test_virtualenv_location_in_docker "$container_name"
+            test_gunicorn_in_docker "$container_name"
+            smoke_test http://localhost:$host_port
+            if [[ $container_name == *fastapi* || $container_name == *starlette* ]]; then
+              smoke_test --user test_user:r4ndom_bUt_memorable http://localhost:$host_port/status
+              smoke_test_xfail --user test_user:incorrect_password http://localhost:$host_port/status
+              smoke_test_xfail http://localhost:$host_port/status
+            fi
+            docker stop "$container_name"
+          }
+
+          container_names=(
+            inboard-base
+            inboard-starlette
+            inboard-fastapi
+            inboard-base-gunicorn-asgi
+            inboard-starlette-gunicorn-asgi
+            inboard-fastapi-gunicorn-asgi
+          )
+
+          for container_name in "${container_names[@]}"; do
+            main "$container_name"
+          done
       - name: Log in to Docker registry
         if: >
           github.ref_type == 'tag' ||
@@ -409,7 +450,7 @@ jobs:
           # https://github.com/br3ndonland/inboard/pull/117
 
           ESCAPE_DUNDERS='s:(\s|\/)(__)(all|init|token)(__)(\s|\.py|\(\)){0,1}:\1\\_\\_\3\\_\\_\5:g'
-          REPLACEMENT='There are several breaking changes noted in the\n[Gunicorn changelog](https://docs.gunicorn.org/en/latest/news.html).'
+          REPLACEMENT='There are several breaking changes noted in the\n[Gunicorn changelog](https://gunicorn.org/news/).'
           sed -Ei "$ESCAPE_DUNDERS" "docs/changelog.md"
           sed -Ei \
             -e "s|\[Changes\]\(https://docs.gunicorn.org/en/latest/news.html\) include|$REPLACEMENT|g" \

--- a/cspell.json
+++ b/cspell.json
@@ -101,6 +101,7 @@
     "typeshed",
     "unittests",
     "uvicorn",
+    "uvloop",
     "vendorizes",
     "venv",
     "virtualenv",

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -20,12 +20,12 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
 
 ## General
 
-`APP_MODULE`/`UVICORN_APP`
+`APP_MODULE`
 
 <!-- prettier-ignore -->
 - Python module with app instance.
 - Default: The appropriate app module from inboard.
-- Custom: For a module at `/app/package/custom/module.py` and app instance object `api`, either `APP_MODULE` (like `APP_MODULE="package.custom.module:api"`) or `UVICORN_APP` (like `UVICORN_APP="package.custom.module:api"`, _new in inboard 0.62_)
+- Custom: For a module at `/app/package/custom/module.py` and app instance object `api`, `APP_MODULE="package.custom.module:api"`
 
     !!! example "Example of a custom FastAPI app module"
 
@@ -72,7 +72,7 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
 
 `GUNICORN_CONF`
 
-- Path to a [Gunicorn configuration file](https://docs.gunicorn.org/en/latest/settings.html#config-file). Gunicorn accepts either file paths or module paths.
+- Path to a [Gunicorn configuration file](https://gunicorn.org/reference/settings/#config-file). Gunicorn accepts either file paths or module paths.
 - Default:
     - `"python:inboard.gunicorn_conf"` (provided with inboard)
 - Custom:
@@ -81,29 +81,31 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
 
 ### Process management
 
-!!! info
-
-    As originally described in the Uvicorn docs, "Uvicorn includes a Gunicorn worker class allowing you to run ASGI applications, with all of Uvicorn's performance benefits, while also giving you Gunicorn's fully-featured process management."
-
-    Uvicorn deprecated the workers module in version 0.30.0. It is now available here at `inboard.gunicorn_workers`.
-
 `PROCESS_MANAGER`
 
-- Manager for Uvicorn worker processes.
-- Default: `"gunicorn"` (run Uvicorn with Gunicorn as the process manager)
+- Manager for worker processes.
+- Default: `"gunicorn"` (run Gunicorn as the process manager)
 - Custom: `"uvicorn"` (run Uvicorn alone for local development)
 
-[`WORKER_CLASS`](https://docs.gunicorn.org/en/latest/settings.html#worker-processes)
+[`WORKER_CLASS`](https://gunicorn.org/reference/settings/#worker-processes)
 
-- Uvicorn worker class for Gunicorn to use.
+- Worker class for Gunicorn to use.
 - Default: `inboard.gunicorn_workers.UvicornWorker` (provided with inboard)
-- Custom: For the alternate Uvicorn worker, `WORKER_CLASS="inboard.gunicorn_workers.UvicornH11Worker"` _(the H11 worker is provided for [PyPy](https://www.pypy.org/))_
+- Custom:
+    - `WORKER_CLASS="inboard.gunicorn_workers.UvicornH11Worker"` for the alternate Uvicorn H11 worker _(provided for [PyPy](https://www.pypy.org/))_
+    - `WORKER_CLASS="asgi"` for the [Gunicorn ASGI worker](https://gunicorn.org/asgi/)
+
+!!! tip
+
+    As of Gunicorn 25, Gunicorn now provides a new [ASGI worker](https://gunicorn.org/asgi/) that supports uvloop and can run FastAPI, Starlette, Quart, and other ASGI apps without the need for Uvicorn.
+
+    Uvicorn, on the other hand, stopped supporting their ASGI worker and deprecated the workers module in version 0.30.0. It is now available here at `inboard.gunicorn_workers`.
 
 ### Worker process calculation
 
 !!! info
 
-    The number of [Gunicorn worker processes](https://docs.gunicorn.org/en/latest/settings.html#worker-processes) to run is determined based on the `MAX_WORKERS`, `WEB_CONCURRENCY`, and `WORKERS_PER_CORE` environment variables, with a default of 1 worker per CPU core and a default minimum of 2. This is the "performance auto-tuning" feature described in [tiangolo/uvicorn-gunicorn-docker](https://github.com/tiangolo/uvicorn-gunicorn-docker).
+    The number of [Gunicorn worker processes](https://gunicorn.org/reference/settings/#worker-processes) to run is determined based on the `MAX_WORKERS`, `WEB_CONCURRENCY`, and `WORKERS_PER_CORE` environment variables, with a default of 1 worker per CPU core and a default minimum of 2. This is the "performance auto-tuning" feature described in [tiangolo/uvicorn-gunicorn-docker](https://github.com/tiangolo/uvicorn-gunicorn-docker).
 
 `MAX_WORKERS`
 
@@ -135,19 +137,19 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
 
 ### Worker timeouts
 
-[`GRACEFUL_TIMEOUT`](https://docs.gunicorn.org/en/stable/settings.html#graceful-timeout)
+[`GRACEFUL_TIMEOUT`](https://gunicorn.org/reference/settings/#graceful_timeout)
 
 - Number of seconds to wait for workers to finish serving requests before restart.
 - Default: `"120"`
 - Custom: `GRACEFUL_TIMEOUT="20"`
 
-[`TIMEOUT`](https://docs.gunicorn.org/en/stable/settings.html#timeout)
+[`TIMEOUT`](https://gunicorn.org/reference/settings/#timeout)
 
 - Workers silent for more than this many seconds are killed and restarted.
 - Default: `"120"`
 - Custom: `TIMEOUT="20"`
 
-[`KEEP_ALIVE`](https://docs.gunicorn.org/en/stable/settings.html#keepalive)
+[`KEEP_ALIVE`](https://gunicorn.org/reference/settings/#keepalive)
 
 - Number of seconds to wait for workers to finish serving requests on a Keep-Alive connection.
 - Default: `"5"`
@@ -167,7 +169,7 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
 - Default: `"80"`
 - Custom: `PORT="8080"`
 
-[`BIND`](https://docs.gunicorn.org/en/latest/settings.html#server-socket)
+[`BIND`](https://gunicorn.org/reference/settings/#server-socket)
 
 - The actual host and port passed to Gunicorn.
 - Default: `HOST:PORT` (`"0.0.0.0:80"`)
@@ -177,8 +179,8 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
 
 `GUNICORN_CMD_ARGS`
 
-- Additional [command-line arguments for Gunicorn](https://docs.gunicorn.org/en/stable/settings.html). Gunicorn looks for the `GUNICORN_CMD_ARGS` environment variable automatically, and gives these settings precedence over other environment variables and Gunicorn config files.
-- Custom: To use a custom TLS certificate, copy or mount the certificate and private key into the Docker image, and set [`--keyfile` and `--certfile`](http://docs.gunicorn.org/en/latest/settings.html#ssl) to the location of the files.
+- Additional [command-line arguments for Gunicorn](https://gunicorn.org/reference/settings/). Gunicorn looks for the `GUNICORN_CMD_ARGS` environment variable automatically, and gives these settings precedence over other environment variables and Gunicorn config files.
+- Custom: To use a custom TLS certificate, copy or mount the certificate and private key into the Docker image, and set [`--keyfile` and `--certfile`](https://gunicorn.org/reference/settings/#ssl) to the location of the files.
 
     ```sh
     CERTS="--keyfile=/secrets/key.pem --certfile=/secrets/cert.pem"
@@ -193,7 +195,7 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
 
     These settings are mostly used for local development.
 
-    [Uvicorn supports environment variables named with the `UVICORN_` prefix](https://www.uvicorn.org/settings/) (via the [Click `auto_envvar_prefix` feature](https://click.palletsprojects.com/en/7.x/options/#dynamic-defaults-for-prompts)), but these environment variables are only read when running from the CLI. inboard runs Uvicorn programmatically with `uvicorn.run()` instead of running with the CLI, so most of these variables will not apply. The exception is `UVICORN_APP`, as explained in the [general section](#general).
+    [Uvicorn supports environment variables named with the `UVICORN_` prefix](https://www.uvicorn.org/settings/) (via the [Click `auto_envvar_prefix` feature](https://click.palletsprojects.com/en/7.x/options/#dynamic-defaults-for-prompts)), but these environment variables are only read when running from the CLI. inboard runs Uvicorn programmatically with `uvicorn.run()` instead of running with the CLI, so most of these variables will not apply.
 
 `WITH_RELOAD`
 
@@ -260,11 +262,6 @@ ENV APP_MODULE="package.custom.module:api" WORKERS_PER_CORE="2"
         - Parsed into a list of strings in the same manner as for `RELOAD_DIRS`.
         - `uvicorn.run` equivalent: `reload_includes`
         - Uvicorn CLI equivalent: `--reload-include`
-
-`UVICORN_APP` _(new in inboard 0.62)_
-
-- `UVICORN_APP` can be used interchangeably with `APP_MODULE`.
-- See the [general section](#general) for further details.
 
 `UVICORN_CONFIG_OPTIONS` _(advanced usage, new in inboard 0.11)_
 
@@ -363,7 +360,7 @@ The idea here is to allow a catch-all Uvicorn config variable in the spirit of `
 
 `LOG_LEVEL`
 
-- Log level for [Gunicorn](https://docs.gunicorn.org/en/latest/settings.html#logging) or [Uvicorn](https://www.uvicorn.org/settings/#logging).
+- Log level for [Gunicorn](https://gunicorn.org/reference/settings/#logging) or [Uvicorn](https://www.uvicorn.org/settings/#logging).
 - Default: `"info"`
 - Custom (organized from greatest to least amount of logging):
     - `LOG_LEVEL="debug"`

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -251,7 +251,7 @@ The project initially also had support for the old-format `.conf`/`.ini` files, 
 
 - **Dict configs allow programmatic control of logging settings** (see how log level is set in [`logging_conf.py`](https://github.com/br3ndonland/inboard/blob/HEAD/inboard/logging_conf.py) for an example).
 - **Gunicorn and Uvicorn both use dict configs in `.py` files for their own logging configurations**.
-- **Gunicorn prefers dict configs** specified with the [`logconfig_dict` option](https://docs.gunicorn.org/en/latest/settings.html#logconfig-dict).
+- **Gunicorn prefers dict configs** specified with the [`logconfig_dict` option](https://gunicorn.org/reference/settings/#logging).
 - **Uvicorn accepts dict configs when running programmatically**, like `uvicorn.run(log_config=your_dict_config)`.
 - **Relying on Python dictionaries reduces testing burden** (only have to write unit tests for `.py` files)
 - **YAML isn't a Python data structure**. YAML is confusingly used for examples in the documentation, but isn't actually a recommended format. There's no built-in YAML data structure in Python, so the YAML must be parsed by PyYAML and converted into a dictionary, then passed to `logging.config.dictConfig()`. **Why not just make the logging config a dictionary in the first place?**

--- a/inboard/app/main_base.py
+++ b/inboard/app/main_base.py
@@ -21,12 +21,12 @@ def _compose_message() -> str:
     process_manager = os.getenv("PROCESS_MANAGER", "gunicorn")
     if process_manager not in {"gunicorn", "uvicorn"}:
         raise NameError("Process manager needs to be either uvicorn or gunicorn.")
-    server = "Uvicorn" if process_manager == "uvicorn" else "Uvicorn, Gunicorn,"
+    server = "Uvicorn" if process_manager == "uvicorn" else "Gunicorn"
     return f"Hello World, from {server} and Python {version}!"
 
 
 async def app(scope: Scope, _: ASGIReceiveCallable, send: ASGISendCallable) -> None:
-    """Define a simple ASGI 3 application for use with Uvicorn.
+    """Define a simple ASGI 3 application.
 
     https://asgi.readthedocs.io/en/stable/introduction.html
     https://asgi.readthedocs.io/en/stable/specs/main.html#applications

--- a/inboard/app/main_fastapi.py
+++ b/inboard/app/main_fastapi.py
@@ -14,7 +14,7 @@ origin_regex = r"^(https?:\/\/)(localhost|([\w\.]+\.)?br3ndon.land)(:[0-9]+)?$"
 server = (
     "Uvicorn"
     if (value := os.getenv("PROCESS_MANAGER")) and value.title() == "Uvicorn"
-    else "Uvicorn, Gunicorn"
+    else "Gunicorn"
 )
 version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 

--- a/inboard/app/main_starlette.py
+++ b/inboard/app/main_starlette.py
@@ -17,7 +17,7 @@ origin_regex = r"^(https?:\/\/)(localhost|([\w\.]+\.)?br3ndon.land)(:[0-9]+)?$"
 server = (
     "Uvicorn"
     if (value := os.getenv("PROCESS_MANAGER")) and value.title() == "Uvicorn"
-    else "Uvicorn, Gunicorn"
+    else "Gunicorn"
 )
 version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 

--- a/inboard/start.py
+++ b/inboard/start.py
@@ -116,8 +116,12 @@ def start_server(
     logger = logger or logging.getLogger()
     try:
         if process_manager == "gunicorn":
-            logger.debug("Running Uvicorn with Gunicorn.")
             gunicorn_options: list[str] = set_gunicorn_options(app_module)
+            logger.debug(
+                "Running Uvicorn with Gunicorn."
+                if any("uvicorn" in option.casefold() for option in gunicorn_options)
+                else "Running Gunicorn."
+            )
             _ = subprocess.run(gunicorn_options)
         elif process_manager == "uvicorn":
             logger.debug("Running Uvicorn without Gunicorn.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "gunicorn==23.0.0",
+  "gunicorn==25.3.0",
   "uvicorn==0.28.1",
 ]
 dynamic = ["version"]
@@ -38,12 +38,16 @@ Repository = "https://github.com/br3ndonland/inboard"
 fastapi = [
   "fastapi>=0.135,<0.136",
 ]
+gunicorn-fast = [
+  "gunicorn_h1c>=0.6.3",
+  "uvloop>=0.19.0; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",
+]
 starlette = [
   "starlette>=0.46.0",
 ]
 uvicorn-fast = [
   "httptools>=0.6.3",
-  "uvloop>0.15.1; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",
+  "uvloop>=0.19.0; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",
   "websockets>=10.4",
 ]
 uvicorn-standard = [
@@ -93,7 +97,9 @@ packages = ["inboard"]
 
 [tool.hatch.envs.base]
 dev-mode = false
-features = []
+features = [
+  "gunicorn-fast",
+]
 
 [tool.hatch.envs.ci]
 builder = true
@@ -104,6 +110,7 @@ dependency-groups = [
 ]
 features = [
   "fastapi",
+  "gunicorn-fast",
   "uvicorn-fast",
 ]
 
@@ -116,6 +123,7 @@ dependency-groups = [
 ]
 features = [
   "fastapi",
+  "gunicorn-fast",
   "uvicorn-fast",
 ]
 
@@ -143,11 +151,13 @@ dependency-groups = [
 dev-mode = false
 features = [
   "fastapi",
+  "gunicorn-fast",
 ]
 
 [tool.hatch.envs.starlette]
 dev-mode = false
 features = [
+  "gunicorn-fast",
   "starlette",
 ]
 

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -131,7 +131,7 @@ class TestEndpoints:
         response = client_asgi.get("/")
         assert response.status_code == 200
         assert response.text == (
-            f"Hello World, from Uvicorn, Gunicorn, and Python "
+            f"Hello World, from Gunicorn and Python "
             f"{version.major}.{version.minor}.{version.micro}!"
         )
 
@@ -231,7 +231,7 @@ class TestEndpoints:
         assert error_response.status_code in {401, 403}
         assert response.status_code == 200
         assert "message" in response_json
-        for word in ("Hello", "World", "Uvicorn", "Python"):
+        for word in ("Hello", "World", "Python"):
             assert word in response_json["message"]
         if isinstance(client.app, FastAPI):
             assert "FastAPI" in response_json["message"]

--- a/tests/test_gunicorn_workers.py
+++ b/tests/test_gunicorn_workers.py
@@ -29,8 +29,12 @@ if TYPE_CHECKING:
     )
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="requires unix")
+pytestmarks = [pytest.mark.subprocess, pytest.mark.timeout(60)]
 gunicorn_arbiter = pytest.importorskip("gunicorn.arbiter", reason="requires gunicorn")
-gunicorn_workers = pytest.importorskip(
+gunicorn_workers_gasgi = pytest.importorskip(
+    "gunicorn.workers.gasgi", reason="requires gunicorn"
+)
+gunicorn_workers_inboard = pytest.importorskip(
     "inboard.gunicorn_workers", reason="requires gunicorn"
 )
 
@@ -136,8 +140,9 @@ def unused_tcp_port() -> int:
 
 @pytest.fixture(
     params=(
-        pytest.param(gunicorn_workers.UvicornWorker, marks=pytest.mark.subprocess),
-        pytest.param(gunicorn_workers.UvicornH11Worker, marks=pytest.mark.subprocess),
+        pytest.param(gunicorn_workers_gasgi.ASGIWorker, marks=pytestmarks),
+        pytest.param(gunicorn_workers_inboard.UvicornWorker, marks=pytestmarks),
+        pytest.param(gunicorn_workers_inboard.UvicornH11Worker, marks=pytestmarks),
     )
 )
 def worker_class(request: pytest.FixtureRequest) -> str:
@@ -151,7 +156,11 @@ def worker_class(request: pytest.FixtureRequest) -> str:
     https://docs.pytest.org/en/latest/proposals/parametrize_with_fixtures.html
     """
     worker_class = request.param
-    return f"{worker_class.__module__}.{worker_class.__name__}"
+    return (
+        f"{worker_class.__module__}.{worker_class.__name__}"
+        if "uvicorn" in str(worker_class.__name__).casefold()
+        else "asgi"
+    )
 
 
 @pytest.fixture(
@@ -169,7 +178,7 @@ def gunicorn_process(
     unused_tcp_port: int,
     worker_class: str,
 ) -> Generator[Process, None, None]:
-    """Yield a subprocess running a Gunicorn arbiter with a Uvicorn worker.
+    """Yield a subprocess running a Gunicorn arbiter with a worker.
 
     An instance of `httpxyz.Client` is available on the `client` attribute.
     Output is saved to a temporary file and accessed with `read_output()`.
@@ -206,72 +215,23 @@ def gunicorn_process(
         base_url = f"http://{bind}"
         verify = False
     args.append(app_module)
+    transport = httpxyz.HTTPTransport(retries=5, verify=verify)
     with (
-        httpxyz.Client(base_url=base_url, verify=verify) as client,
+        httpxyz.Client(base_url=base_url, transport=transport) as client,
         tempfile.TemporaryFile() as output,
     ):
         with Process(args, client=client, output=output) as process:
             time.sleep(2)
-            assert not process.poll()
-            yield process
-            process.send_signal(signal.SIGQUIT)
-            _ = process.wait(timeout=5)
-
-
-@pytest.fixture
-def gunicorn_process_with_sigterm(
-    unused_tcp_port: int,
-) -> Generator[Process, None, None]:
-    """Yield a subprocess running a Gunicorn arbiter with a Uvicorn worker.
-
-    An instance of `httpxyz.Client` is available on the `client` attribute.
-    Output is saved to a temporary file and accessed with `read_output()`.
-
-    This pytest fixture provides a simplified worker configuration that exits
-    with `SIGTERM` instead of `SIGQUIT`. Exiting with `SIGTERM` seems to help
-    coverage.py report the correct code coverage, even without the configuration
-    setting `sigterm = true` on `coverage.run`, but test processes also seem to
-    re-spawn unexpectedly. Coverage.py continues generating `.coverage.*` files,
-    even after the test run has concluded. This is why `SIGQUIT` is used instead
-    of `SIGTERM` in the more complex `gunicorn_process` fixture. The idea is to
-    use `SIGTERM` as little as possible to avoid these re-spawning subprocesses.
-    """
-    worker_class = (
-        f"{gunicorn_workers.UvicornWorker.__module__}."
-        f"{gunicorn_workers.UvicornWorker.__name__}"
-    )
-    app_module = f"{__name__}:{app.__name__}"
-    bind = f"127.0.0.1:{unused_tcp_port}"
-    args = [
-        "gunicorn",
-        "--bind",
-        bind,
-        "--graceful-timeout",
-        "1",
-        "--log-level",
-        "debug",
-        "--worker-class",
-        worker_class,
-        "--workers",
-        "1",
-        app_module,
-    ]
-    base_url = f"http://{bind}"
-    verify = False
-    with (
-        httpxyz.Client(base_url=base_url, verify=verify) as client,
-        tempfile.TemporaryFile() as output,
-    ):
-        with Process(args, client=client, output=output) as process:
-            time.sleep(2)
+            assert process.poll() is None
             yield process
             process.terminate()
             _ = process.wait(timeout=5)
+            assert process.poll() is not None
 
 
 @pytest.fixture
 def gunicorn_process_with_lifespan_startup_failure(
-    unused_tcp_port: int, worker_class: str
+    unused_tcp_port: int,
 ) -> Generator[Process, None, None]:
     """Yield a subprocess running a Gunicorn arbiter with a Uvicorn worker.
 
@@ -289,7 +249,7 @@ def gunicorn_process_with_lifespan_startup_failure(
         "--log-level",
         "debug",
         "--worker-class",
-        worker_class,
+        "inboard.gunicorn_workers.UvicornWorker",
         "--workers",
         "1",
         app_module,
@@ -317,7 +277,7 @@ def test_gunicorn_arbiter_signal_handling(
     sends each signal to the process running the arbiter, and asserts that
     Gunicorn handles the signal and logs the signal handling event accordingly.
 
-    https://docs.gunicorn.org/en/latest/signals.html
+    https://gunicorn.org/signals/
     """
     signal_abbreviation = gunicorn_arbiter.Arbiter.SIG_NAMES[signal_to_send]
     expected_text = f"Handling signal: {signal_abbreviation}"
@@ -330,7 +290,6 @@ def test_gunicorn_arbiter_signal_handling(
         # occasional flakes are seen with certain signals
         flaky_signals = [
             getattr(signal, "SIGHUP", None),
-            getattr(signal, "SIGTERM", None),
             getattr(signal, "SIGTTIN", None),
             getattr(signal, "SIGTTOU", None),
             getattr(signal, "SIGUSR2", None),
@@ -365,21 +324,10 @@ def test_uvicorn_worker_boot_error(
     assert "Worker failed to boot" in output_text
 
 
-def test_uvicorn_worker_get_request(gunicorn_process: Process) -> None:
-    """Test a GET request to the Gunicorn Uvicorn worker's ASGI app."""
+def test_worker_get_request(gunicorn_process: Process) -> None:
+    """Test a GET request to the Gunicorn worker's ASGI app."""
     response = gunicorn_process.client.get("/")
     output_text = gunicorn_process.read_output()
     assert response.status_code == 204
-    assert "inboard.gunicorn_workers", "startup complete" in output_text
-
-
-def test_uvicorn_worker_get_request_with_sigterm(
-    gunicorn_process_with_sigterm: Process,
-) -> None:
-    """Test a GET request to the Gunicorn Uvicorn worker's ASGI app
-    when `SIGTERM` is used to stop the process instead of `SIGQUIT`.
-    """
-    response = gunicorn_process_with_sigterm.client.get("/")
-    output_text = gunicorn_process_with_sigterm.read_output()
-    assert response.status_code == 204
-    assert "inboard.gunicorn_workers", "startup complete" in output_text
+    assert "gunicorn" in output_text
+    assert "Listening" in output_text


### PR DESCRIPTION
## Description

Gunicorn has [released](https://gunicorn.org/news/) new versions recently. The new versions provide many new features and bug fixes.

Of particular note, Gunicorn now provides a new [ASGI worker](https://gunicorn.org/asgi/) that supports uvloop and can run FastAPI, Starlette, Quart, and other ASGI apps without the need for Uvicorn.

Gunicorn also now provides an [official Docker image](https://gunicorn.org/guides/docker/). It's not something that would be used in this project because it only supports a single version of Python and a single Linux distribution (Debian "slim"), but it is an additional resource for the community.

## Changes

This PR will update Gunicorn from 23.0.0 to 25.3.0.

Users can select the new Gunicorn ASGI worker with inboard by setting the environment variable `WORKER_CLASS=asgi`. The inboard test suite will be updated to include test cases that run the Gunicorn ASGI worker without Uvicorn.

Gunicorn 25 offers compatibility with additional dependencies for improved performance.

1. A new `gunicorn[fast]` extra includes the HTTP parser [`gunicorn_h1c`](https://github.com/benoitc/gunicorn_h1c).
2. The Gunicorn ASGI worker supports `uvloop`, but Gunicorn does not provide an optional extra for installing `uvloop`.

A new `inboard[gunicorn-fast]` extra will be added for installation of `gunicorn_h1c` and `uvloop` with Gunicorn, and will be installed by default now that both Gunicorn and Uvicorn support a common version of `uvloop`. The `uvloop` version will align with the version used for testing by [Gunicorn](https://github.com/benoitc/gunicorn/blob/9bce72cfc3985aba7e0c47bf3c00fa681b2847e4/pyproject.toml#L65).

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/HEAD/docs/contributing.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/HEAD/.github/CODE_OF_CONDUCT.md).
- [Gunicorn changelog](https://gunicorn.org/news/)
- benoitc/gunicorn#3509 _(this change in 25.2.0 was necessary to pass subprocess tests)_
