### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -62,7 +62,7 @@ jobs:
           *) echo "Incorrect Hatch virtualenv." && exit 1 ;;
           esac
       - name: Test that Git tag version and Python package version match
-        if: github.ref_type == 'tag' && matrix.python-version == '3.13'
+        if: github.ref_type == 'tag' && matrix.python-version == '3.14'
         run: |
           GIT_TAG_VERSION=$GITHUB_REF_NAME
           PACKAGE_VERSION=$(hatch version)
@@ -101,7 +101,7 @@ jobs:
       - name: Build Python package
         run: hatch build
       - name: Upload Python package artifacts
-        if: github.ref_type == 'tag' && matrix.python-version == '3.13'
+        if: github.ref_type == 'tag' && matrix.python-version == '3.14'
         uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         linux-version: ["alpine", "trixie", "slim-trixie"]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -285,7 +285,7 @@ jobs:
             -u ${{ github.actor }} --password-stdin
       - name: Tag and push Docker images with latest tags
         if: >
-          matrix.python-version == '3.13' &&
+          matrix.python-version == '3.14' &&
           (
             github.ref_type == 'tag' ||
             github.ref == 'refs/heads/develop' ||

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION=3.13 LINUX_VERSION=
+ARG PYTHON_VERSION=3.14 LINUX_VERSION=
 FROM python:${PYTHON_VERSION}${LINUX_VERSION:+-$LINUX_VERSION} AS builder
 LABEL org.opencontainers.image.authors="Brendon Smith <bws@bws.bio>"
 LABEL org.opencontainers.image.description="Docker images and utilities to power your Python APIs and help you ship faster."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Internet :: Log Analysis",
   "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
   "Topic :: Internet :: WWW/HTTP :: WSGI",


### PR DESCRIPTION
## Description

This PR will add [Python 3.14](https://docs.python.org/3/whatsnew/3.14.html) support to inboard.

## Changes

### Code changes

- Add Python 3.14 to GitHub Actions workflows
- Add Python 3.14 classifier to `pyproject.toml`
- Set Python 3.14 as default version in `Dockerfile`

### Results

- inboard will now run tests with Python 3.14, in addition to 3.10-3.13
- inboard will now build and publish its PyPI package using Python 3.14
- inboard will now include a Python 3.14 classifier in its PyPI package
- inboard will now ship Docker images running Python 3.14, in addition to 3.10-3.13, and Docker images tagged with `latest` will now use 3.14

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/develop/.github/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/develop/.github/CODE_OF_CONDUCT.md).

Related projects that have released support for Python 3.14 include:

- AnyIO ([4.10.0 - 2025-08-04](https://github.com/agronholm/anyio/releases/tag/4.10.0))
- FastAPI ([0.118.3 - 2025-10-10](https://github.com/fastapi/fastapi/releases/tag/0.118.3))
- gunicorn_h1c ([0.6.1 - 2026-03-26](https://github.com/benoitc/gunicorn_h1c/releases/tag/v0.6.1))
- Hatch ([1.15.0 - 2025-10-15](https://github.com/pypa/hatch/releases/tag/hatch-v1.15.0))
- httptools ([0.7.0 - 2025-10-10](https://github.com/MagicStack/httptools/releases/tag/v0.7.0))
- pipx ([1.9.0 - 2026-03-17](https://github.com/pypa/pipx/releases/tag/1.9.0))
- Pydantic ([2.12.0 - 2025-10-07](https://github.com/pydantic/pydantic/releases/tag/v2.12.0))
- Starlette ([0.48.0 - 2025-09-13](https://github.com/Kludex/starlette/releases/tag/0.48.0))
- Uvicorn ([0.38.0 - 2025-10-18](https://github.com/Kludex/uvicorn/releases/tag/0.38.0))
- uvloop ([0.22.0 - 2025-10-16](https://github.com/MagicStack/uvloop/releases/tag/v0.22.0))
- websockets ([16.0 - 2026-01-10](https://github.com/python-websockets/websockets/releases/tag/16.0))

Related projects that have not released support for Python 3.14 include:

- [Gunicorn](https://github.com/benoitc/gunicorn) ([25.3.0](https://github.com/benoitc/gunicorn/releases/tag/25.3.0) updated its Docker images to Python 3.14, but its package classifiers and test matrix only cover through Python 3.13)