### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         linux-version: ["alpine", "trixie", "slim-trixie"]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/inboard/types.py
+++ b/inboard/types.py
@@ -3,15 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 if TYPE_CHECKING:
-    import sys
     from asyncio import Protocol
     from collections.abc import Sequence
     from os import PathLike
-
-    if sys.version_info < (3, 11):
-        from typing_extensions import Required
-    else:
-        from typing import Required  # pyright: ignore[reportUnreachable]
+    from typing import Required
 
     from uvicorn._types import ASGIApplication
     from uvicorn.config import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "inboard"
 description = "Docker images and utilities to power your Python APIs and help you ship faster."
 readme = "docs/index.md"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.11,<4"
 license = "MIT"
 authors = [{ name = "Brendon Smith", email = "bws@bws.bio" }]
 keywords = ["asgi", "docker", "fastapi", "gunicorn", "uvicorn"]
@@ -10,7 +10,6 @@ classifiers = [
   "Framework :: FastAPI",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -77,7 +76,7 @@ requires = ["hatchling>=1.26.3,<2"]
 build-backend = "hatchling.build"
 
 [tool.basedpyright]
-pythonVersion = "3.10"
+pythonVersion = "3.11"
 reportImplicitOverride = "information"
 
 [tool.coverage.report]


### PR DESCRIPTION
## Description

Python 3.10 is in security-only maintenance and reaches [end-of-life](https://devguide.python.org/versions/) in October 2026.

## Changes

This PR will:

- Require Python 3.11 or newer.
- Remove Python 3.10 from the GitHub Actions matrices and package classifiers.
- Import `typing.Required` directly now that Python 3.11 is required.

## Related

- [x] I have reviewed the [Guidelines for Contributing](https://github.com/br3ndonland/inboard/blob/HEAD/docs/contributing.md) and the [Code of Conduct](https://github.com/br3ndonland/inboard/blob/HEAD/.github/CODE_OF_CONDUCT.md).
- [Python Developer's Guide: Status of Python versions](https://devguide.python.org/versions/)
